### PR TITLE
Building a bacpac & paywall VM with ZendPHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The one-off manual steps to rectify this are as follows:
         User vagrant
     ```
 5. Change the access permissions on the `config` and `private_key` files to 0600: `chmod 0600 config private_key`
-6. Test that you have set this up by SSHing to the VM from within as the vagrant user `ssh 192.168.33.35` - you'll need
+6. Test that you have set this up correctly by SSHing to the VM from within as the vagrant user `ssh 192.168.33.35` - you'll need
 to accept the question about connecting to an unknown host; don't forget to `exit` before continuing with provisioning
 the VM.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ vagrant up (this will fail at the initial Ansible provision step)
 (copy generated vagrant user private key into VM and set up SSH config - see below for one-off intervention)
 vagrant reload --provision
 ```
-Ansible cannot be installed on Windows, and so it will be installed into the VM by Vagrant and then run from within to provision the VM. However the initial Ansible run fails as the VM needs to be able to provision itself via an SSH connection but cannot connect.
+Ansible cannot be installed on Windows, and so it will be installed into the VM by Vagrant and then run from within to
+provision the VM. However, the initial Ansible run fails as the VM needs to be able to provision itself via an SSH
+connection but cannot connect at this stage.
 The one-off manual steps to rectify this are as follows:
 1. Copy the generated `private_key` from `.vagrant/machines/default/virtualbox` into the VM for vagrant user as `~/.ssh.private_key`
 2. SSH into the VM
@@ -36,7 +38,22 @@ The one-off manual steps to rectify this are as follows:
         User vagrant
     ```
 5. Change the access permissions on the `config` and `private_key` files to 0600: `chmod 0600 config private_key`
-6. Test that you have set this up by SSHing to the VM from within as the vagrant user `ssh 192.168.33.35` - you'll need to accept the question about connecting to an unknown host; don't forget to `exit` before continuing with provisioning the VM.
+6. Test that you have set this up by SSHing to the VM from within as the vagrant user `ssh 192.168.33.35` - you'll need
+to accept the question about connecting to an unknown host; don't forget to `exit` before continuing with provisioning
+the VM.
+
+For Windows hosts, two aliases are added into the `~/.bashrc` file
+- `vendormount` to mount bind '~/vendor' to `/bacpac/vendor`
+- `vendorunmount` to remove the above mount.
+These have been added to specifically work around shared folder issues for Windows hosts while working on **bacpac**.
+
+## Shared directories
+Host-VM shared directories have been set up for:
+- `/vagrant` (the standard share of the host directory in which the Vagrantfile resides)
+- `/ansible` (this repository's `ansible` directory required for Ansible provisioning when on Windows hosts)
+- `/bacpac` (this expects to find the `bacpac` codebase in a directory name `bacpac` at the same level as this repository)
+
+The `bacpac` share can be adjusted as required.
 
 ### Add Virtual Hosts
 Add a new entry to the `virtual_hosts` dictionary in the `ansible/group_vars/all` file. Set the `host_name` to the virtual host that you would like to use.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 
 ### Run
 
+Edit the `all` file to suit once copied.
+Note that, for a VM suitable for bacpac and paywall, the `fastcgi_read_timeout` value in `all.example` has been updated to 300s as per task #142741, but only needs to be this value for bacpac. For paywall it must be reset to 60s after the VM has been built by manually editing the generated nginx configuration file for the paywall host in the VM (generated in `/etc/nginx/conf.d/`), setting the value back to `60`, then reloading the nginx configuration (`nginx -t` to test the change, if ok then run `sudo service nginx reload`) .
+
 For Macs:
 ```
 cp ansible/group_vars/all.example ansible/group_vars/all
@@ -93,17 +96,17 @@ After changing any ansible settings just run `vagrant up --provision` to propaga
 
 ### Default Config File Locations Inside The Virtual Machine
 **Nginx**
-- error log setting : `/var/log/php-fpm/error.log`
+- error log setting : `/var/log/php-fpm/error.log` (When using ZendPHP, this becomes `/opt/zend/php56zend/root/var/log/php-fpm/error.log`)
 - nginx configuration : `/etc/nginx/nginx.conf`
 
 **PHP**
-- php.ini file is at : `/opt/remi/php56/root/etc/php.ini`
-- Xdebug executable : `/opt/remi/php56/root/usr/lib64/php/modules/xdebug.so`
-- xdebug.ini file at : `/opt/remi/php56/root/etc/php.d/15-xdebug.ini`
+- php.ini file is at : `/opt/remi/php56/root/etc/php.ini` (When using ZendPHP, this becomes `/opt/zend/php56zend/root/etc/php.ini`)
+- Xdebug executable : `/opt/remi/php56/root/usr/lib64/php/modules/xdebug.so` (When using ZendPHP, this becomes `/opt/zend/php56zend/root/usr/lib64/php/56zend/modules/xdebug.so`)
+- xdebug.ini file at : `/opt/remi/php56/root/etc/php.d/15-xdebug.ini` (When using ZendPHP, this becomes `/opt/zend/php56zend/root/etc/php.d/xdebug.ini`)
 
 **CentOS**
 - Restart nginx : `sudo service nginx restart`
-- To restart PHP-FPM : `sudo service php56-php-fpm restart`
+- To restart PHP-FPM : `sudo service php56-php-fpm restart` (When using ZendPHP, this becomes `sudo service php56zend-php-fpm restart`)
 
 ### Running multiple machines
 - Duplicate the `"default"` block in `Vagrantfile`

--- a/README.md
+++ b/README.md
@@ -1,18 +1,42 @@
 # Centos 6 LNMP Stack
 - Centos 6.5
-- NginX
-- MySQL 5.7
-- PHP 5.6/7.2/7.3
-- Node
-- NPM
-- Memcache
+- NginX 1.10.3
+- MySQL 5.5/5.7
+- PHP 5.5/5.6/7.2/7.3
+- Node 11
+- NPM 6.7.0
+- Memcache 1.4.1
 
 ### Run
+
+For Macs:
 ```
 cp ansible/group_vars/all.example ansible/group_vars/all
 vagrant plugin install vagrant-vbguest
 vagrant up
 ```
+
+For Windows:
+```
+cp ansible/group_vars/all.example ansible/group_vars/all
+vagrant plugin install vagrant-vbguest
+vagrant up (this will fail at the initial Ansible provision step)
+(copy generated vagrant user private key into VM and set up SSH config - see below for one-off intervention)
+vagrant reload --provision
+```
+Ansible cannot be installed on Windows, and so it will be installed into the VM by Vagrant and then run from within to provision the VM. However the initial Ansible run fails as the VM needs to be able to provision itself via an SSH connection but cannot connect.
+The one-off manual steps to rectify this are as follows:
+1. Copy the generated `private_key` from `.vagrant/machines/default/virtualbox` into the VM for vagrant user as `~/.ssh.private_key`
+2. SSH into the VM
+3. Change directory to `~/.ssh`
+4. Create the SSH configuration file `~/.ssh/config` with the following content (using spaces rather than tabs):
+    ```
+    Host 192.168.33.35
+        IdentityFile ~/.ssh/private_key
+        User vagrant
+    ```
+5. Change the access permissions on the `config` and `private_key` files to 0600: `chmod 0600 config private_key`
+6. Test that you have set this up by SSHing to the VM from within as the vagrant user `ssh 192.168.33.35` - you'll need to accept the question about connecting to an unknown host; don't forget to `exit` before continuing with provisioning the VM.
 
 ### Add Virtual Hosts
 Add a new entry to the `virtual_hosts` dictionary in the `ansible/group_vars/all` file. Set the `host_name` to the virtual host that you would like to use.
@@ -21,7 +45,7 @@ Add the following line `192.168.33.35 {host_name}` (where the `{host_name}` is t
 
 ### Change PHP Versions
 Edit `ansible/group_vars/all` with your favourite editor and change
-the `php_version` variable. 5.6 and 7.2 are the only allowed version numbers at this time.
+the `php_version` variable. 5.5, 5.6 7.1 and 7.2 are the only allowed version numbers at this time.
 
 ### Update Dependencies
 After changing any ansible settings just run `vagrant up --provision` to propagate the changes to the VM.
@@ -39,7 +63,7 @@ After changing any ansible settings just run `vagrant up --provision` to propaga
 
   Install VirtualBox, instructions can be found here: [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 
-- **Ansible**
+- **Ansible (Mac only)**
 
   Install Ansible, instructions can be found here: [Ansible](http://docs.ansible.com/ansible/intro_installation.html#installing-the-control-machine)
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Add the following line `192.168.33.35 {host_name}` (where the `{host_name}` is t
 Edit `ansible/group_vars/all` with your favourite editor and change
 the `php_version` variable. 5.5, 5.6 7.1 and 7.2 are the only allowed version numbers at this time.
 
+### Change MySQL Versions
+Edit `ansible/group_vars/all` with your favourite editor and change
+the `mysql_version` variable. 5.5 and 5.7 are the only allowed version numbers at this time.
+
 ### Update Dependencies
 After changing any ansible settings just run `vagrant up --provision` to propagate the changes to the VM.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Ansible cannot be installed on Windows, and so it will be installed into the VM 
 provision the VM. However, the initial Ansible run fails as the VM needs to be able to provision itself via an SSH
 connection but cannot connect at this stage.
 The one-off manual steps to rectify this are as follows:
-1. Copy the generated `private_key` from `.vagrant/machines/default/virtualbox` into the VM for vagrant user as `~/.ssh.private_key`
+1. Copy the generated `private_key` from `.vagrant/machines/default/virtualbox` into the VM for vagrant user as `~/.ssh/private_key`
 2. SSH into the VM
 3. Change directory to `~/.ssh`
 4. Create the SSH configuration file `~/.ssh/config` with the following content (using spaces rather than tabs):
@@ -38,7 +38,7 @@ The one-off manual steps to rectify this are as follows:
         User vagrant
     ```
 5. Change the access permissions on the `config` and `private_key` files to 0600: `chmod 0600 config private_key`
-6. Test that you have set this up correctly by SSHing to the VM from within as the vagrant user `ssh 192.168.33.35` - you'll need
+6. Required step: Test that you have set this up correctly by SSHing to the VM from within as the vagrant user `ssh 192.168.33.35` - you'll need
 to accept the question about connecting to an unknown host; don't forget to `exit` before continuing with provisioning
 the VM.
 
@@ -52,8 +52,9 @@ Host-VM shared directories have been set up for:
 - `/vagrant` (the standard share of the host directory in which the Vagrantfile resides)
 - `/ansible` (this repository's `ansible` directory required for Ansible provisioning when on Windows hosts)
 - `/bacpac` (this expects to find the `bacpac` codebase in a directory name `bacpac` at the same level as this repository)
+- `/paywall` (this expects to find the `paywall` codebase in a directory name `paywall` at the same level as this repository)
 
-The `bacpac` share can be adjusted as required.
+The `bacpac` and `paywall` shares can be adjusted as required.
 
 ### Add Virtual Hosts
 Add a new entry to the `virtual_hosts` dictionary in the `ansible/group_vars/all` file. Set the `host_name` to the virtual host that you would like to use.
@@ -61,12 +62,14 @@ Add a new entry to the `virtual_hosts` dictionary in the `ansible/group_vars/all
 Add the following line `192.168.33.35 {host_name}` (where the `{host_name}` is the one from the `all` file) to your hosts file `/etc/hosts`
 
 ### Change PHP Versions
-Edit `ansible/group_vars/all` with your favourite editor and change
-the `php_version` variable. 5.5, 5.6 7.1 and 7.2 are the only allowed version numbers at this time.
+
+Edit `ansible/group_vars/all` with your favourite editor and change the `php_version` variable. The only allowed version
+numbers at this time are for PHP 5.5, 5.6, 7.2, 7.4 and Zend PHP 5.6.40 (use `5.5`, `5.6`, `7.2`, `7.4` or `Zend5.6`).
+The Zend PHP selection is only for use with bacpac and paywall and requires the use of credentials stored in 1Password.
 
 ### Change MySQL Versions
 Edit `ansible/group_vars/all` with your favourite editor and change
-the `mysql_version` variable. 5.5 and 5.7 are the only allowed version numbers at this time.
+the `mysql_version` variable. The only allowed version numbers at this time are 5.5 and 5.7.
 
 ### Update Dependencies
 After changing any ansible settings just run `vagrant up --provision` to propagate the changes to the VM.
@@ -88,7 +91,7 @@ After changing any ansible settings just run `vagrant up --provision` to propaga
 
   Install Ansible, instructions can be found here: [Ansible](http://docs.ansible.com/ansible/intro_installation.html#installing-the-control-machine)
 
-### Config File Location Inside The Virtual Machine
+### Default Config File Locations Inside The Virtual Machine
 **Nginx**
 - error log setting : `/var/log/php-fpm/error.log`
 - nginx configuration : `/etc/nginx/nginx.conf`
@@ -99,8 +102,8 @@ After changing any ansible settings just run `vagrant up --provision` to propaga
 - xdebug.ini file at : `/opt/remi/php56/root/etc/php.d/15-xdebug.ini`
 
 **CentOS**
-- restart nginx : `sudo service nginx restart`
-- to restart PHP-FPM : `sudo service php56-php-fpm restart`
+- Restart nginx : `sudo service nginx restart`
+- To restart PHP-FPM : `sudo service php56-php-fpm restart`
 
 ### Running multiple machines
 - Duplicate the `"default"` block in `Vagrantfile`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,6 +79,9 @@ Vagrant.configure("2") do |config|
         ansible.playbook = "ansible/install.yml"
         ansible.inventory_path = "ansible/hosts"
         ansible.verbose = true
+        ansible.extra_vars = {
+          windowshost: false
+        }
       end
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,28 @@ Vagrant.configure("2") do |config|
     default.vm.network "forwarded_port", guest: 3306, host: 6612
 
     default.vm.network :private_network, ip: "192.168.33.35"
+
+    # Need to adjust specific yum.repos.d/*.repo files due to CentOS6 being EOL
+    default.vbguest.installer_hooks[:before_install] = [
+    "cd /etc/yum.repos.d; if [ ! -f \"CentOS-Base.repo.bak\" ]; then printf \"Backing up CentOS-Base.repo file\"; sudo cp /etc/yum.repos.d/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo.bak; fi",
+    "printf \"Amending CentOS-Base.repo\"",
+    "sudo sed -i 's|^mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/CentOS-Base.repo",
+    "sudo sed -i 's|^#baseurl=|baseurl=|g' /etc/yum.repos.d/CentOS-Base.repo",
+    "sudo sed -i 's|^baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Base.repo",
+    "printf \"Install scl\"",
+    "sudo yum install -y centos-release-scl",
+    "cd /etc/yum.repos.d; if [ ! -f \"CentOS-SCLo-scl.repo.bak\" ]; then printf \"Backing up CentOS-SCLo-scl.repo file\"; sudo cp /etc/yum.repos.d/CentOS-SCLo-scl.repo /etc/yum.repos.d/CentOS-SCLo-scl.repo.bak; fi",
+    "printf \"Amending CentOS-SCLo-scl.repo\"",
+    "sudo sed -i 's|^mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/CentOS-SCLo-scl.repo",
+    "sudo sed -i 's|^# baseurl=|baseurl=|g' /etc/yum.repos.d/CentOS-SCLo-scl.repo",
+    "sudo sed -i 's|^baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-SCLo-scl.repo",
+    "cd /etc/yum.repos.d; if [ ! -f \"CentOS-SCLo-scl-rh.repo.bak\" ]; then printf \"Backing up CentOS-SCLo-scl-rh.repo file\"; sudo cp /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo.bak; fi",
+    "printf \"Amending CentOS-SCLo-scl-rh.repo\"",
+    "sudo sed -i 's|^mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo",
+    "sudo sed -i 's|^#baseurl=|baseurl=|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo",
+    "sudo sed -i 's|^baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo"
+    ]
+
     # Shared folder
     if OS.windows?
       default.vm.synced_folder "www", "/vagrant", type: "virtualbox"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,22 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+
+#Check OS host version
+module OS
+  def OS.windows?
+    (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+  end
+  def OS.mac?
+    (/darwin/ =~ RUBY_PLATFORM) != nil
+  end
+  def OS.unix?
+    !OS.windows?
+  end
+  def OS.linux?
+    OS.unix? and not OS.mac?
+  end
+end
+
 Vagrant.configure("2") do |config|
   config.vm.define "default" do |default|
     default.vm.box = "centos/6"
@@ -7,19 +24,35 @@ Vagrant.configure("2") do |config|
     default.vm.network "forwarded_port", guest: 3306, host: 6612
 
     default.vm.network :private_network, ip: "192.168.33.35"
+    # Shared folder
+    if OS.windows?
+      default.vm.synced_folder "www", "/vagrant"
+      default.vm.synced_folder "ansible", "/ansible"
+      default.vm.synced_folder "../bacpac", "/bacpac"
+    end
+    if OS.linux?
+      default.vm.synced_folder "www", "/vagrant", :nfs => true
+      default.vm.synced_folder "ansible", "/ansible", :nfs => true
+      default.vm.synced_folder "../bacpac", "/bacpac", :nfs => true
+    end
+    if OS.mac?
+      default.vm.synced_folder "www", "/vagrant", :nfs => true, mount_options: ['rw', 'vers=3', 'tcp', 'fsc' ,'actimeo=2']
+      default.vm.synced_folder "ansible", "/ansible", :nfs => true, mount_options: ['rw', 'vers=3', 'tcp', 'fsc', 'actimeo=2']
+      default.vm.synced_folder "../bacpac", "/bacpac", :nfs => true, mount_options: ['rw', 'vers=3', 'tcp', 'fsc', 'actimeo=2']
+    end
 
-    default.vm.synced_folder "www/", "/vagrant", type: "nfs"
 
     default.vm.provider "virtualbox" do |v|
       v.memory = 2048
       v.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
     end
 
-    default.vm.provision "ansible" do |ansible|
+    default.vm.provision "ansible_local" do |ansible|
       ansible.compatibility_mode = "2.0"
-      ansible.playbook = "ansible/install.yml"
-      ansible.inventory_path = "ansible/hosts"
+      ansible.playbook = "/ansible/install.yml"
+      ansible.inventory_path = "/ansible/hosts"
       ansible.verbose = true
+      ansible.provisioning_path = "/ansible"
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,16 +51,19 @@ Vagrant.configure("2") do |config|
       default.vm.synced_folder "www", "/vagrant", type: "virtualbox"
       default.vm.synced_folder "ansible", "/ansible", type: "virtualbox"
       default.vm.synced_folder "../bacpac", "/bacpac", type: "virtualbox"
+      default.vm.synced_folder "../paywall", "/paywall", type: "virtualbox"
     end
     if OS.linux?
       default.vm.synced_folder "www", "/vagrant", :nfs => true
       default.vm.synced_folder "ansible", "/ansible", :nfs => true
       default.vm.synced_folder "../bacpac", "/bacpac", :nfs => true
+      default.vm.synced_folder "../paywall", "/paywall", :nfs => true
     end
     if OS.mac?
       default.vm.synced_folder "www", "/vagrant", :nfs => true, mount_options: ['rw', 'vers=3', 'tcp', 'fsc' ,'actimeo=2']
       default.vm.synced_folder "ansible", "/ansible", :nfs => true, mount_options: ['rw', 'vers=3', 'tcp', 'fsc', 'actimeo=2']
       default.vm.synced_folder "../bacpac", "/bacpac", :nfs => true, mount_options: ['rw', 'vers=3', 'tcp', 'fsc', 'actimeo=2']
+      default.vm.synced_folder "../paywall", "/paywall", :nfs => true, mount_options: ['rw', 'vers=3', 'tcp', 'fsc', 'actimeo=2']
     end
 
 
@@ -100,7 +103,8 @@ Vagrant.configure("2") do |config|
         ansible.compatibility_mode = "2.0"
         ansible.playbook = "ansible/install.yml"
         ansible.inventory_path = "ansible/hosts"
-        ansible.verbose = true
+        # Uncomment the next line for increased output from Ansible provisioning, change to "-vvv" for debug level output
+        #ansible.verbose = true
         ansible.extra_vars = {
           windowshost: false
         }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,12 +47,19 @@ Vagrant.configure("2") do |config|
       v.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
     end
 
-    default.vm.provision "ansible_local" do |ansible|
-      ansible.compatibility_mode = "2.0"
-      ansible.playbook = "/ansible/install.yml"
-      ansible.inventory_path = "/ansible/hosts"
-      ansible.verbose = true
-      ansible.provisioning_path = "/ansible"
+    if OS.windows?
+      default.vm.provision "ansible_local" do |ansible|
+        ansible.compatibility_mode = "2.0"
+        ansible.playbook = "/ansible/install.yml"
+        ansible.inventory_path = "/ansible/hosts"
+        ansible.verbose = true
+        ansible.provisioning_path = "/ansible"
+    else
+      default.vm.provision "ansible" do |ansible|
+        ansible.compatibility_mode = "2.0"
+        ansible.playbook = "ansible/install.yml"
+        ansible.inventory_path = "ansible/hosts"
+        ansible.verbose = true
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,12 +54,18 @@ Vagrant.configure("2") do |config|
         ansible.inventory_path = "/ansible/hosts"
         ansible.verbose = true
         ansible.provisioning_path = "/ansible"
+        ansible.extra_vars = {
+          windowshost: true
+        }
+
+      end
     else
       default.vm.provision "ansible" do |ansible|
         ansible.compatibility_mode = "2.0"
         ansible.playbook = "ansible/install.yml"
         ansible.inventory_path = "ansible/hosts"
         ansible.verbose = true
+      end
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,9 +26,9 @@ Vagrant.configure("2") do |config|
     default.vm.network :private_network, ip: "192.168.33.35"
     # Shared folder
     if OS.windows?
-      default.vm.synced_folder "www", "/vagrant"
-      default.vm.synced_folder "ansible", "/ansible"
-      default.vm.synced_folder "../bacpac", "/bacpac"
+      default.vm.synced_folder "www", "/vagrant", type: "virtualbox"
+      default.vm.synced_folder "ansible", "/ansible", type: "virtualbox"
+      default.vm.synced_folder "../bacpac", "/bacpac", type: "virtualbox"
     end
     if OS.linux?
       default.vm.synced_folder "www", "/vagrant", :nfs => true

--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -27,7 +27,7 @@ mysql_root_db_pass: 'SomeSuperLongPassword1234!'
 #    value: 1024
 
 # MySQL version
-mysql_version: "5.5"
+mysql_version: "5.7"
 
 # Node Version - Node v11 is the latest that supports Centos6
 node_version: v11

--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -35,6 +35,10 @@ fastcgi_read_timeout: 60
 # PHP Version
 php_version: "5.6"
 
+# ZendPHP PHP 5.6 repository credentials - for use with Zend PHP installation for bacpac only - see 1Password
+zendphp_username:
+zendphp_password:
+
 # NginX Virtual Hosts
 virtual_hosts:
     - name: example

--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -26,6 +26,9 @@ mysql_root_db_pass: 'SomeSuperLongPassword1234!'
 #  - setting: 'group_concat_max_len'
 #    value: 1024
 
+# MySQL version
+mysql_version: "5.5"
+
 # Node Version - Node v11 is the latest that supports Centos6
 node_version: v11
 

--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -33,7 +33,7 @@ mysql_version: "5.7"
 node_version: v11
 
 # Timeout
-fastcgi_read_timeout: 60
+fastcgi_read_timeout: 300
 
 # PHP Version
 php_version: "5.6"

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -7,8 +7,8 @@
   - core
   - yum
   - selinux
-  - { role: mysql-55, when mysql_version == "5.5"}
-  - { role: mysql-57, when mysql_version == "5.7"}
+  - { role: mysql-55, when: mysql_version == "5.5"}
+  - { role: mysql-57, when: mysql_version == "5.7"}
   - memcached
   - php-remove
   - { role: php-55, when: php_version == "5.5" }

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -15,6 +15,7 @@
   - { role: php-56, when: php_version == "5.6" }
   - { role: php-72, when: php_version == "7.2" }
   - { role: php-73, when: php_version == "7.3" }
+  - { role: php-56-zend, when: php_version == "Zend5.6" }
   - nodejs
   - nginx
   - hosts-file

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -7,7 +7,8 @@
   - core
   - yum
   - selinux
-  - mysql-57
+  - { role: mysql-55, when mysql_version == "5.5"}
+  - { role: mysql-57, when mysql_version == "5.7"}
   - memcached
   - php-remove
   - { role: php-55, when: php_version == "5.5" }

--- a/ansible/roles/check-variables/tasks/main.yml
+++ b/ansible/roles/check-variables/tasks/main.yml
@@ -6,6 +6,7 @@
     - php_version != "5.6"
     - php_version != "7.2"
     - php_version != "7.3"
+    - php_version != "Zend5.6"
 
 - fail:
     msg: "Invalid MySQL Version"

--- a/ansible/roles/check-variables/tasks/main.yml
+++ b/ansible/roles/check-variables/tasks/main.yml
@@ -6,3 +6,9 @@
     - php_version != "5.6"
     - php_version != "7.2"
     - php_version != "7.3"
+
+- fail:
+    msg: "Invalid MySQL Version"
+  when:
+    - mysql_version != "5.5"
+    - mysql_version != "5.7"

--- a/ansible/roles/composer/tasks/main.yml
+++ b/ansible/roles/composer/tasks/main.yml
@@ -1,21 +1,17 @@
 ---
-- name: Find PHP
+- name: Find PHP binary
   find:
     paths: /usr/bin/
-    patterns: ^php[0-9]+$
+    patterns: "{{ lookup('vars', 'phppattern') }}"
     use_regex: yes
     file_type: link
   register: php_binarys
-  when: php_version != "Zend5.6"
 
-- name: Find PHP when using Zend PHP
-  find:
-    paths: /usr/bin/
-    patterns: ^php$
-    use_regex: yes
-    file_type: link
-  register: php_binarys
-  when: php_version == "Zend5.6"
+- name: foo1
+  debug: var=phppattern
+
+- name: foo
+  debug: var=php_binarys
 
 - name: Install PHP Composer 1.10.8
   get_url:

--- a/ansible/roles/composer/tasks/main.yml
+++ b/ansible/roles/composer/tasks/main.yml
@@ -7,9 +7,9 @@
     file_type: link
   register: php_binarys
 
-- name: Install PHP Composer 1.10.7
+- name: Install PHP Composer 1.10.8
   get_url:
-    url: https://getcomposer.org/download/1.10.7/composer.phar
+    url: https://getcomposer.org/download/1.10.8/composer.phar
     dest: /usr/local/bin/composer
     mode: 0755
 

--- a/ansible/roles/composer/tasks/main.yml
+++ b/ansible/roles/composer/tasks/main.yml
@@ -6,6 +6,16 @@
     use_regex: yes
     file_type: link
   register: php_binarys
+  when: php_version != "Zend5.6"
+
+- name: Find PHP when using Zend PHP
+  find:
+    paths: /usr/bin/
+    patterns: ^php$
+    use_regex: yes
+    file_type: link
+  register: php_binarys
+  when: php_version == "Zend5.6"
 
 - name: Install PHP Composer 1.10.8
   get_url:

--- a/ansible/roles/composer/tasks/main.yml
+++ b/ansible/roles/composer/tasks/main.yml
@@ -7,9 +7,9 @@
     file_type: link
   register: php_binarys
 
-- name: Install PHP Composer
+- name: Install PHP Composer 1.10.7
   get_url:
-    url: https://getcomposer.org/composer.phar
+    url: https://getcomposer.org/download/1.10.7/composer.phar
     dest: /usr/local/bin/composer
     mode: 0755
 

--- a/ansible/roles/composer/vars/main.yml
+++ b/ansible/roles/composer/vars/main.yml
@@ -1,0 +1,2 @@
+---
+phppattern: "{{ ['^', ((php_version == 'Zend5.6')|ternary('php', 'php[0-9]+'))|string, '$']|join() }}"

--- a/ansible/roles/hosts-file/tasks/main.yml
+++ b/ansible/roles/hosts-file/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: Adding virtual hosts to hosts file
-  lineinfile: dest=/etc/hosts regexp='.*{{ item.host_name }}$' line="127.0.1.1 {{ item.host_name }}" state=present
+  lineinfile: dest=/etc/hosts regexp='.*{{ item.host_name }}$' line="127.0.0.1 {{ item.host_name }}" state=present
   with_items: "{{ virtual_hosts }}"

--- a/ansible/roles/mysql-55/handlers/main.yml
+++ b/ansible/roles/mysql-55/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: restart mysql
+  service:
+    name: mysqld
+    state: restarted
+  changed_when: false
+  failed_when: false

--- a/ansible/roles/mysql-55/tasks/main.yml
+++ b/ansible/roles/mysql-55/tasks/main.yml
@@ -34,13 +34,7 @@
     state: started
     enabled: true
 
-- name: Temp Root Config
-  shell: grep "temporary password" /var/log/mysqld.log | cut -d ' ' -f 11
-  register: temporary_mysql_password
-  changed_when: false
-  failed_when: false
-
-- name: Create root MySQL configuration file
+- name: Create root MySQL configuration file (will be replaced)
   template:
     src: my-default-root.cnf.j2
     dest: ~/.my.cnf
@@ -48,12 +42,12 @@
   failed_when: false
 
 - name: testusers
-  shell: mysql --connect-expired-password -e "ALTER USER USER() IDENTIFIED BY '#!SomeLongPassword1234'"
+  shell: 'mysql -e "UPDATE mysql.user SET PASSWORD=PASSWORD(''SomeLongPassword1234XYZ'') WHERE user=''root''; FLUSH PRIVILEGES;" -uroot'
   changed_when: false
   failed_when: false
 
 - name: update mysql root password for all root accounts
-  mysql_user: name={{ mysql_root_db_user }} host={{ item }} password={{ mysql_root_db_pass }} priv='*.*:ALL,GRANT' login_user='root' login_password='#!SomeLongPassword1234'
+  mysql_user: name={{ mysql_root_db_user }} host={{ item }} password={{ mysql_root_db_pass }} priv='*.*:ALL,GRANT' login_user='root' login_password='SomeLongPassword1234XYZ'
   with_items:
    - '%'
 
@@ -82,4 +76,4 @@
     host: localhost
     state: absent
     login_user: 'root'
-    login_password: '#!SomeLongPassword1234'
+    login_password: 'SomeLongPassword1234XYZ'

--- a/ansible/roles/mysql-55/tasks/main.yml
+++ b/ansible/roles/mysql-55/tasks/main.yml
@@ -1,0 +1,85 @@
+---
+- name: Create MySQL configuration file
+  template: src=my.cnf.j2 dest=/etc/my.cnf
+  changed_when: false
+  failed_when: false
+
+- name: Set custom mysqld configuration
+  lineinfile:
+    path: /etc/my.cnf
+    line: '{{item.setting}}={{item.value}}'
+    insertafter: '\[mysqld\]'
+  with_items: "{{ mysqld | default([]) }}"
+  changed_when: false
+
+- name: Set custom mysqld_safe configuration
+  lineinfile:
+    path: /etc/my.cnf
+    line: '{{item.setting}}={{item.value}}'
+    insertafter: '\[mysqld_safe\]'
+  with_items: "{{ mysqld_safe | default([]) }}"
+  changed_when: false
+
+- name: Set custom client configuration
+  lineinfile:
+    path: /etc/my.cnf
+    line: '{{item.setting}}={{item.value}}'
+    insertafter: '\[client\]'
+  with_items: "{{ client | default([]) }}"
+  changed_when: false
+
+- name: Start the MySQL service
+  service:
+    name: mysqld
+    state: started
+    enabled: true
+
+- name: Temp Root Config
+  shell: grep "temporary password" /var/log/mysqld.log | cut -d ' ' -f 11
+  register: temporary_mysql_password
+  changed_when: false
+  failed_when: false
+
+- name: Create root MySQL configuration file
+  template:
+    src: my-default-root.cnf.j2
+    dest: ~/.my.cnf
+  changed_when: false
+  failed_when: false
+
+- name: testusers
+  shell: mysql --connect-expired-password -e "ALTER USER USER() IDENTIFIED BY '#!SomeLongPassword1234'"
+  changed_when: false
+  failed_when: false
+
+- name: update mysql root password for all root accounts
+  mysql_user: name={{ mysql_root_db_user }} host={{ item }} password={{ mysql_root_db_pass }} priv='*.*:ALL,GRANT' login_user='root' login_password='#!SomeLongPassword1234'
+  with_items:
+   - '%'
+
+- name: Create root user MySQL configuration file
+  template:
+    src: my-root.cnf.j2
+    dest: ~/.my.cnf
+  notify: restart mysql
+  changed_when: false
+  failed_when: false
+
+- name: Make the input settings less likely to destroy a whole SQL query
+  template: src=editrc dest=~/.editrc
+
+- name: Create vagrant user MySQL configuration file
+  become: true
+  become_user: vagrant
+  template:
+    src: my-root.cnf.j2
+    dest: ~/.my.cnf
+  notify: restart mysql
+
+- name: ensure anonymous users are not in the database
+  mysql_user:
+    name: ''
+    host: localhost
+    state: absent
+    login_user: 'root'
+    login_password: '#!SomeLongPassword1234'

--- a/ansible/roles/mysql-55/templates/editrc
+++ b/ansible/roles/mysql-55/templates/editrc
@@ -1,0 +1,2 @@
+bind "^W" ed-delete-prev-word
+bind "^U" vi-kill-line-prev

--- a/ansible/roles/mysql-55/templates/my-default-root.cnf.j2
+++ b/ansible/roles/mysql-55/templates/my-default-root.cnf.j2
@@ -1,0 +1,3 @@
+[client]
+user=root
+password='{{ temporary_mysql_password.stdout }}'

--- a/ansible/roles/mysql-55/templates/my-default-root.cnf.j2
+++ b/ansible/roles/mysql-55/templates/my-default-root.cnf.j2
@@ -1,3 +1,2 @@
 [client]
 user=root
-password='{{ temporary_mysql_password.stdout }}'

--- a/ansible/roles/mysql-55/templates/my-root.cnf.j2
+++ b/ansible/roles/mysql-55/templates/my-root.cnf.j2
@@ -1,0 +1,6 @@
+[client]
+user={{ mysql_root_db_user }}
+password='{{ mysql_root_db_pass }}'
+
+[mysql]
+prompt='(\u@\h) [\d]> '

--- a/ansible/roles/mysql-55/templates/my.cnf.j2
+++ b/ansible/roles/mysql-55/templates/my.cnf.j2
@@ -7,9 +7,7 @@ symbolic-links=0
 port={{ mysql_port }}
 character-set-server=utf8
 collation-server=utf8_general_ci
-explicit_defaults_for_timestamp=1
 log-error=/var/log/mysqld.log
-default_password_lifetime=0
 sql_mode=NO_ENGINE_SUBSTITUTION
 
 [mysqld_safe]

--- a/ansible/roles/mysql-55/templates/my.cnf.j2
+++ b/ansible/roles/mysql-55/templates/my.cnf.j2
@@ -1,0 +1,19 @@
+[mysqld]
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+user=mysql
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+port={{ mysql_port }}
+character-set-server=utf8
+collation-server=utf8_general_ci
+explicit_defaults_for_timestamp=1
+log-error=/var/log/mysqld.log
+default_password_lifetime=0
+sql_mode=NO_ENGINE_SUBSTITUTION
+
+[mysqld_safe]
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid
+
+[client]

--- a/ansible/roles/php-55/tasks/main.yml
+++ b/ansible/roles/php-55/tasks/main.yml
@@ -18,6 +18,7 @@
     - php55-php-pecl-memcached
     - php55-php-mcrypt
     - php55-php-fpm
+    - php55-php-gd
 
 - name: set access log file
   file:

--- a/ansible/roles/php-56-zend/tasks/main.yml
+++ b/ansible/roles/php-56-zend/tasks/main.yml
@@ -3,31 +3,32 @@
   yum:
     name: "{{ packages }}"
     state: latest
-    enablerepo: zend-server,zend-server-noarch
+    enablerepo: zendphp
   vars:
     packages:
-    - php5.6-zend
-    - php5.6-common-zend
-    - php5.6-bcmath-zend
-    - php5.6-bz2-zend
-    - php5.6-curl-zend
-    - php5.6-gd-zend
-    - php5.6-intl-zend
-    - php5.6-mbstring-zend
-    - php5.6-mcrypt-zend
-    - php5.6-memcache-zend
-    - php5.6-memcached-zend
-    - php5.6-mysql-zend
-    - php5.6-mysqli-zend
-    - php5.6-pcntl-zend
-    - php5.6-pdo-mysql-zend
-    - php5.6-soap-zend
-    - php5.6-wddx-zend
-    - php5.6-xdebug-zend
-    - php5.6-xsl-zend
-    - php5.6-zip-zend
-    - php5.6-fpm-zend
-    - php5.6-fpm-nginx-conf-zend
+    - php56zend-php-cli
+    - php56zend-syspaths
+    - php56zend-php-common
+    - php56zend-php-bcmath
+    - php56zend-php-bz2
+    - php56zend-php-curl
+    - php56zend-php-gd
+    - php56zend-php-intl
+    - php56zend-php-mbstring
+    - php56zend-php-mcrypt
+#    - php56zend-php-memcache #unavailable at present, not needed for bacpac?
+#    - php56zend-php-memcached #unavailable at present, broken dependency chain (installs php56zend-php-pecl-memcached and requires php56zend-php-json), not needed for bacpac?
+    - php56zend-php-mysql
+    - php56zend-php-mysqli
+    - php56zend-php-pcntl
+#    - php56zend-php-pdo-mysql #unavailable at present (mysqlnd is available and installed as part of common)
+    - php56zend-php-soap
+    - php56zend-php-wddx
+    - php56zend-php-xdebug
+    - php56zend-php-xsl
+    - php56zend-php-zip
+    - php56zend-php-fpm
+#    - php56zend-php-fpm-nginx-conf #unavailable at present
 
 - name: set access log file
   file:
@@ -38,12 +39,12 @@
 - name: php.ini file
   template:
     src: php.ini
-    dest: /usr/local/zend/php/5.6/etc/php.ini
+    dest: /opt/zend/php56zend/root/etc/php.ini
 
 - name: www.cnf file
   template:
     src: www.conf
-    dest: /usr/local/zend/php/5.6/etc/fpm.d/www.conf
+    dest: /opt/zend/php56zend/root/etc/php-fpm.d/www.conf
 
 - name: create php session directory
   file:
@@ -74,7 +75,7 @@
 
 - name: start php-fpm
   service:
-    name: php-fpm
+    name: php56zend-php-fpm
     state: started
     enabled: true
 

--- a/ansible/roles/php-56-zend/tasks/main.yml
+++ b/ansible/roles/php-56-zend/tasks/main.yml
@@ -56,7 +56,7 @@
 
 - name: custom xdebug configuration .ini file
   template:
-    src: xedug.ini
+    src: xdebug.ini
     dest: /opt/zend/php56zend/root/etc/php.d/xdebug-conf.ini
 
 - name: www.cnf file

--- a/ansible/roles/php-56-zend/tasks/main.yml
+++ b/ansible/roles/php-56-zend/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+- name: install Zend PHP 5.6 prerequisites
+  yum:
+    name: "{{packages}}"
+    state: latest
+  vars:
+    packages:
+      - gcc
+      - gcc-c++
+      - make
+
+- name: enable Software Collections package
+  shell: "yum-config-manager --enable centos-release-scl-rh"
+
 - name: install Zend PHP 5.6
   yum:
     name: "{{ packages }}"
@@ -6,8 +19,8 @@
     enablerepo: zendphp
   vars:
     packages:
+    - php56zend
     - php56zend-php-cli
-    - php56zend-syspaths
     - php56zend-php-common
     - php56zend-php-bcmath
     - php56zend-php-bz2
@@ -16,19 +29,19 @@
     - php56zend-php-intl
     - php56zend-php-mbstring
     - php56zend-php-mcrypt
-#    - php56zend-php-memcache #unavailable at present, not needed for bacpac?
-#    - php56zend-php-memcached #unavailable at present, broken dependency chain (installs php56zend-php-pecl-memcached and requires php56zend-php-json), not needed for bacpac?
+    - php56zend-php-memcached
     - php56zend-php-mysql
     - php56zend-php-mysqli
     - php56zend-php-pcntl
-#    - php56zend-php-pdo-mysql #unavailable at present (mysqlnd is available and installed as part of common)
     - php56zend-php-soap
     - php56zend-php-wddx
     - php56zend-php-xdebug
     - php56zend-php-xsl
     - php56zend-php-zip
     - php56zend-php-fpm
-#    - php56zend-php-fpm-nginx-conf #unavailable at present
+    - php56zend-php-devel
+    - php56zend-php-pear
+    - php56zend-syspaths
 
 - name: set access log file
   file:

--- a/ansible/roles/php-56-zend/tasks/main.yml
+++ b/ansible/roles/php-56-zend/tasks/main.yml
@@ -1,0 +1,80 @@
+---
+- name: install Zend PHP 5.6
+  yum:
+    name: "{{ packages }}"
+    state: latest
+    enablerepo: zend-server,zend-server-noarch
+  vars:
+    packages:
+    - php5.6-zend
+    - php5.6-common-zend
+    - php5.6-bcmath-zend
+    - php5.6-bz2-zend
+    - php5.6-curl-zend
+    - php5.6-gd-zend
+    - php5.6-intl-zend
+    - php5.6-mbstring-zend
+    - php5.6-mcrypt-zend
+    - php5.6-memcache-zend
+    - php5.6-memcached-zend
+    - php5.6-mysql-zend
+    - php5.6-mysqli-zend
+    - php5.6-pcntl-zend
+    - php5.6-pdo-mysql-zend
+    - php5.6-soap-zend
+    - php5.6-wddx-zend
+    - php5.6-xdebug-zend
+    - php5.6-xsl-zend
+    - php5.6-zip-zend
+    - php5.6-fpm-zend
+    - php5.6-fpm-nginx-conf-zend
+
+- name: set access log file
+  file:
+    state: directory
+    path: /var/log/php-fpm
+    mode: 0777
+
+- name: php.ini file
+  template:
+    src: php.ini
+    dest: /usr/local/zend/php/5.6/etc/php.ini
+
+- name: www.cnf file
+  template:
+    src: www.conf
+    dest: /usr/local/zend/php/5.6/etc/fpm.d/www.conf
+
+- name: create php session directory
+  file:
+    state: directory
+    path: /var/lib/php/session
+    mode: 0777
+
+- name: set access log file
+  file:
+    state: touch
+    dest: /var/log/php-fpm/access.log
+    mode: 0777
+  changed_when: false
+
+- name: set error log file
+  file:
+    state: touch
+    dest: /var/log/php-fpm/error.log
+    mode: 0777
+  changed_when: false
+
+- name: set slow log file
+  file:
+    state: touch
+    dest: /var/log/php-fpm/slow.log
+    mode: 0777
+  changed_when: false
+
+- name: start php-fpm
+  service:
+    name: php-fpm
+    state: started
+    enabled: true
+

--- a/ansible/roles/php-56-zend/tasks/main.yml
+++ b/ansible/roles/php-56-zend/tasks/main.yml
@@ -56,7 +56,7 @@
 
 - name: custom xdebug configuration .ini file
   template:
-    src: xdebug.ini
+    src: xdebug-conf.ini
     dest: /opt/zend/php56zend/root/etc/php.d/xdebug-conf.ini
 
 - name: www.cnf file

--- a/ansible/roles/php-56-zend/tasks/main.yml
+++ b/ansible/roles/php-56-zend/tasks/main.yml
@@ -54,6 +54,11 @@
     src: php.ini
     dest: /opt/zend/php56zend/root/etc/php.ini
 
+- name: custom xdebug configuration .ini file
+  template:
+    src: xedug.ini
+    dest: /opt/zend/php56zend/root/etc/php.d/xdebug-conf.ini
+
 - name: www.cnf file
   template:
     src: www.conf

--- a/ansible/roles/php-56-zend/templates/php.ini
+++ b/ansible/roles/php-56-zend/templates/php.ini
@@ -1,0 +1,2041 @@
+[PHP]
+
+;;;;;;;;;;;;;;;;;;;
+; About php.ini   ;
+;;;;;;;;;;;;;;;;;;;
+; PHP's initialization file, generally called php.ini, is responsible for
+; configuring many of the aspects of PHP's behavior.
+
+; PHP attempts to find and load this configuration from a number of locations.
+; The following is a summary of its search order:
+; 1. SAPI module specific location.
+; 2. The PHPRC environment variable. (As of PHP 5.2.0)
+; 3. A number of predefined registry keys on Windows (As of PHP 5.2.0)
+; 4. Current working directory (except CLI)
+; 5. The web server's directory (for SAPI modules), or directory of PHP
+; (otherwise in Windows)
+; 6. The directory from the --with-config-file-path compile time option, or the
+; Windows directory (C:\windows or C:\winnt)
+; See the PHP docs for more specific information.
+; http://php.net/configuration.file
+
+; The syntax of the file is extremely simple.  Whitespace and lines
+; beginning with a semicolon are silently ignored (as you probably guessed).
+; Section headers (e.g. [Foo]) are also silently ignored, even though
+; they might mean something in the future.
+
+; Directives following the section heading [PATH=/www/mysite] only
+; apply to PHP files in the /www/mysite directory.  Directives
+; following the section heading [HOST=www.example.com] only apply to
+; PHP files served from www.example.com.  Directives set in these
+; special sections cannot be overridden by user-defined INI files or
+; at runtime. Currently, [PATH=] and [HOST=] sections only work under
+; CGI/FastCGI.
+; http://php.net/ini.sections
+
+; Directives are specified using the following syntax:
+; directive = value
+; Directive names are *case sensitive* - foo=bar is different from FOO=bar.
+; Directives are variables used to configure PHP or PHP extensions.
+; There is no name validation.  If PHP can't find an expected
+; directive because it is not set or is mistyped, a default value will be used.
+
+; The value can be a string, a number, a PHP constant (e.g. E_ALL or M_PI), one
+; of the INI constants (On, Off, True, False, Yes, No and None) or an expression
+; (e.g. E_ALL & ~E_NOTICE), a quoted string ("bar"), or a reference to a
+; previously set variable or directive (e.g. ${foo})
+
+; Expressions in the INI file are limited to bitwise operators and parentheses:
+; |  bitwise OR
+; ^  bitwise XOR
+; &  bitwise AND
+; ~  bitwise NOT
+; !  boolean NOT
+
+; Boolean flags can be turned on using the values 1, On, True or Yes.
+; They can be turned off using the values 0, Off, False or No.
+
+; An empty string can be denoted by simply not writing anything after the equal
+; sign, or by using the None keyword:
+
+;  foo =         ; sets foo to an empty string
+;  foo = None    ; sets foo to an empty string
+;  foo = "None"  ; sets foo to the string 'None'
+
+; If you use constants in your value, and these constants belong to a
+; dynamically loaded extension (either a PHP extension or a Zend extension),
+; you may only use these constants *after* the line that loads the extension.
+
+;;;;;;;;;;;;;;;;;;;
+; About this file ;
+;;;;;;;;;;;;;;;;;;;
+; PHP comes packaged with two INI files. One that is recommended to be used
+; in production environments and one that is recommended to be used in
+; development environments.
+
+; php.ini-production contains settings which hold security, performance and
+; best practices at its core. But please be aware, these settings may break
+; compatibility with older or less security conscience applications. We
+; recommending using the production ini in production and testing environments.
+
+; php.ini-development is very similar to its production variant, except it is
+; much more verbose when it comes to errors. We recommend using the
+; development version only in development environments, as errors shown to
+; application users can inadvertently leak otherwise secure information.
+
+; This is php.ini-production INI file.
+
+;;;;;;;;;;;;;;;;;;;
+; Quick Reference ;
+;;;;;;;;;;;;;;;;;;;
+; The following are all the settings which are different in either the production
+; or development versions of the INIs with respect to PHP's default behavior.
+; Please see the actual settings later in the document for more details as to why
+; we recommend these changes in PHP's behavior.
+
+; display_errors
+;   Default Value: On
+;   Development Value: On
+;   Production Value: Off
+
+; display_startup_errors
+;   Default Value: Off
+;   Development Value: On
+;   Production Value: Off
+
+; error_reporting
+;   Default Value: E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
+;   Development Value: E_ALL
+;   Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
+
+; html_errors
+;   Default Value: On
+;   Development Value: On
+;   Production value: On
+
+; log_errors
+;   Default Value: Off
+;   Development Value: On
+;   Production Value: On
+
+; max_input_time
+;   Default Value: -1 (Unlimited)
+;   Development Value: 60 (60 seconds)
+;   Production Value: 60 (60 seconds)
+
+; output_buffering
+;   Default Value: Off
+;   Development Value: 4096
+;   Production Value: 4096
+
+; register_argc_argv
+;   Default Value: On
+;   Development Value: Off
+;   Production Value: Off
+
+; request_order
+;   Default Value: None
+;   Development Value: "GP"
+;   Production Value: "GP"
+
+; session.gc_divisor
+;   Default Value: 100
+;   Development Value: 1000
+;   Production Value: 1000
+
+; session.hash_bits_per_character
+;   Default Value: 4
+;   Development Value: 5
+;   Production Value: 5
+
+; short_open_tag
+;   Default Value: On
+;   Development Value: Off
+;   Production Value: Off
+
+; track_errors
+;   Default Value: Off
+;   Development Value: On
+;   Production Value: Off
+
+; url_rewriter.tags
+;   Default Value: "a=href,area=href,frame=src,form=,fieldset="
+;   Development Value: "a=href,area=href,frame=src,input=src,form=fakeentry"
+;   Production Value: "a=href,area=href,frame=src,input=src,form=fakeentry"
+
+; variables_order
+;   Default Value: "EGPCS"
+;   Development Value: "GPCS"
+;   Production Value: "GPCS"
+
+;;;;;;;;;;;;;;;;;;;;
+; php.ini Options  ;
+;;;;;;;;;;;;;;;;;;;;
+; Name for user-defined php.ini (.htaccess) files. Default is ".user.ini"
+;user_ini.filename = ".user.ini"
+
+; To disable this feature set this option to empty value
+;user_ini.filename =
+
+; TTL for user-defined php.ini files (time-to-live) in seconds. Default is 300 seconds (5 minutes)
+;user_ini.cache_ttl = 300
+
+;;;;;;;;;;;;;;;;;;;;
+; Language Options ;
+;;;;;;;;;;;;;;;;;;;;
+
+; Enable the PHP scripting language engine under Apache.
+; http://php.net/engine
+engine = On
+
+; This directive determines whether or not PHP will recognize code between
+; <? and ?> tags as PHP source which should be processed as such. It is
+; generally recommended that <?php and ?> should be used and that this feature
+; should be disabled, as enabling it may result in issues when generating XML
+; documents, however this remains supported for backward compatibility reasons.
+; Note that this directive does not control the <?= shorthand tag, which can be
+; used regardless of this directive.
+; Default Value: On
+; Development Value: Off
+; Production Value: Off
+; http://php.net/short-open-tag
+short_open_tag = Off
+
+; Allow ASP-style <% %> tags.
+; http://php.net/asp-tags
+asp_tags = Off
+
+; The number of significant digits displayed in floating point numbers.
+; http://php.net/precision
+precision = 14
+
+; Output buffering is a mechanism for controlling how much output data
+; (excluding headers and cookies) PHP should keep internally before pushing that
+; data to the client. If your application's output exceeds this setting, PHP
+; will send that data in chunks of roughly the size you specify.
+; Turning on this setting and managing its maximum buffer size can yield some
+; interesting side-effects depending on your application and web server.
+; You may be able to send headers and cookies after you've already sent output
+; through print or echo. You also may see performance benefits if your server is
+; emitting less packets due to buffered output versus PHP streaming the output
+; as it gets it. On production servers, 4096 bytes is a good setting for performance
+; reasons.
+; Note: Output buffering can also be controlled via Output Buffering Control
+;   functions.
+; Possible Values:
+;   On = Enabled and buffer is unlimited. (Use with caution)
+;   Off = Disabled
+;   Integer = Enables the buffer and sets its maximum size in bytes.
+; Note: This directive is hardcoded to Off for the CLI SAPI
+; Default Value: Off
+; Development Value: 4096
+; Production Value: 4096
+; http://php.net/output-buffering
+output_buffering = 4096
+
+; You can redirect all of the output of your scripts to a function.  For
+; example, if you set output_handler to "mb_output_handler", character
+; encoding will be transparently converted to the specified encoding.
+; Setting any output handler automatically turns on output buffering.
+; Note: People who wrote portable scripts should not depend on this ini
+;   directive. Instead, explicitly set the output handler using ob_start().
+;   Using this ini directive may cause problems unless you know what script
+;   is doing.
+; Note: You cannot use both "mb_output_handler" with "ob_iconv_handler"
+;   and you cannot use both "ob_gzhandler" and "zlib.output_compression".
+; Note: output_handler must be empty if this is set 'On' !!!!
+;   Instead you must use zlib.output_handler.
+; http://php.net/output-handler
+;output_handler =
+
+; Transparent output compression using the zlib library
+; Valid values for this option are 'off', 'on', or a specific buffer size
+; to be used for compression (default is 4KB)
+; Note: Resulting chunk size may vary due to nature of compression. PHP
+;   outputs chunks that are few hundreds bytes each as a result of
+;   compression. If you prefer a larger chunk size for better
+;   performance, enable output_buffering in addition.
+; Note: You need to use zlib.output_handler instead of the standard
+;   output_handler, or otherwise the output will be corrupted.
+; http://php.net/zlib.output-compression
+zlib.output_compression = Off
+
+; http://php.net/zlib.output-compression-level
+;zlib.output_compression_level = -1
+
+; You cannot specify additional output handlers if zlib.output_compression
+; is activated here. This setting does the same as output_handler but in
+; a different order.
+; http://php.net/zlib.output-handler
+;zlib.output_handler =
+
+; Implicit flush tells PHP to tell the output layer to flush itself
+; automatically after every output block.  This is equivalent to calling the
+; PHP function flush() after each and every call to print() or echo() and each
+; and every HTML block.  Turning this option on has serious performance
+; implications and is generally recommended for debugging purposes only.
+; http://php.net/implicit-flush
+; Note: This directive is hardcoded to On for the CLI SAPI
+implicit_flush = Off
+
+; The unserialize callback function will be called (with the undefined class'
+; name as parameter), if the unserializer finds an undefined class
+; which should be instantiated. A warning appears if the specified function is
+; not defined, or if the function doesn't include/implement the missing class.
+; So only set this entry, if you really want to implement such a
+; callback-function.
+unserialize_callback_func =
+
+; When floats & doubles are serialized store serialize_precision significant
+; digits after the floating point. The default value ensures that when floats
+; are decoded with unserialize, the data will remain the same.
+serialize_precision = 17
+
+; open_basedir, if set, limits all file operations to the defined directory
+; and below.  This directive makes most sense if used in a per-directory
+; or per-virtualhost web server configuration file.
+; http://php.net/open-basedir
+;open_basedir =
+
+; This directive allows you to disable certain functions for security reasons.
+; It receives a comma-delimited list of function names.
+; http://php.net/disable-functions
+disable_functions =
+
+; This directive allows you to disable certain classes for security reasons.
+; It receives a comma-delimited list of class names.
+; http://php.net/disable-classes
+disable_classes =
+
+; Colors for Syntax Highlighting mode.  Anything that's acceptable in
+; <span style="color: ???????"> would work.
+; http://php.net/syntax-highlighting
+;highlight.string  = #DD0000
+;highlight.comment = #FF9900
+;highlight.keyword = #007700
+;highlight.default = #0000BB
+;highlight.html    = #000000
+
+; If enabled, the request will be allowed to complete even if the user aborts
+; the request. Consider enabling it if executing long requests, which may end up
+; being interrupted by the user or a browser timing out. PHP's default behavior
+; is to disable this feature.
+; http://php.net/ignore-user-abort
+;ignore_user_abort = On
+
+; Determines the size of the realpath cache to be used by PHP. This value should
+; be increased on systems where PHP opens many files to reflect the quantity of
+; the file operations performed.
+; http://php.net/realpath-cache-size
+;realpath_cache_size = 16k
+
+; Duration of time, in seconds for which to cache realpath information for a given
+; file or directory. For systems with rarely changing files, consider increasing this
+; value.
+; http://php.net/realpath-cache-ttl
+;realpath_cache_ttl = 120
+
+; Enables or disables the circular reference collector.
+; http://php.net/zend.enable-gc
+zend.enable_gc = On
+
+; If enabled, scripts may be written in encodings that are incompatible with
+; the scanner.  CP936, Big5, CP949 and Shift_JIS are the examples of such
+; encodings.  To use this feature, mbstring extension must be enabled.
+; Default: Off
+;zend.multibyte = Off
+
+; Allows to set the default encoding for the scripts.  This value will be used
+; unless "declare(encoding=...)" directive appears at the top of the script.
+; Only affects if zend.multibyte is set.
+; Default: ""
+;zend.script_encoding =
+
+;;;;;;;;;;;;;;;;;
+; Miscellaneous ;
+;;;;;;;;;;;;;;;;;
+
+; Decides whether PHP may expose the fact that it is installed on the server
+; (e.g. by adding its signature to the Web server header).  It is no security
+; threat in any way, but it makes it possible to determine whether you use PHP
+; on your server or not.
+; http://php.net/expose-php
+expose_php = On
+
+;;;;;;;;;;;;;;;;;;;
+; Resource Limits ;
+;;;;;;;;;;;;;;;;;;;
+
+; Maximum execution time of each script, in seconds
+; http://php.net/max-execution-time
+; Note: This directive is hardcoded to 0 for the CLI SAPI
+max_execution_time = 30
+
+; Maximum amount of time each script may spend parsing request data. It's a good
+; idea to limit this time on productions servers in order to eliminate unexpectedly
+; long running scripts.
+; Note: This directive is hardcoded to -1 for the CLI SAPI
+; Default Value: -1 (Unlimited)
+; Development Value: 60 (60 seconds)
+; Production Value: 60 (60 seconds)
+; http://php.net/max-input-time
+max_input_time = 60
+
+; Maximum input variable nesting level
+; http://php.net/max-input-nesting-level
+;max_input_nesting_level = 64
+
+; How many GET/POST/COOKIE input variables may be accepted
+; max_input_vars = 1000
+
+; Maximum amount of memory a script may consume (128MB)
+; http://php.net/memory-limit
+memory_limit = 128M
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Error handling and logging ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; This directive informs PHP of which errors, warnings and notices you would like
+; it to take action for. The recommended way of setting values for this
+; directive is through the use of the error level constants and bitwise
+; operators. The error level constants are below here for convenience as well as
+; some common settings and their meanings.
+; By default, PHP is set to take action on all errors, notices and warnings EXCEPT
+; those related to E_NOTICE and E_STRICT, which together cover best practices and
+; recommended coding standards in PHP. For performance reasons, this is the
+; recommend error reporting setting. Your production server shouldn't be wasting
+; resources complaining about best practices and coding standards. That's what
+; development servers and development settings are for.
+; Note: The php.ini-development file has this setting as E_ALL. This
+; means it pretty much reports everything which is exactly what you want during
+; development and early testing.
+;
+; Error Level Constants:
+; E_ALL             - All errors and warnings (includes E_STRICT as of PHP 5.4.0)
+; E_ERROR           - fatal run-time errors
+; E_RECOVERABLE_ERROR  - almost fatal run-time errors
+; E_WARNING         - run-time warnings (non-fatal errors)
+; E_PARSE           - compile-time parse errors
+; E_NOTICE          - run-time notices (these are warnings which often result
+;                     from a bug in your code, but it's possible that it was
+;                     intentional (e.g., using an uninitialized variable and
+;                     relying on the fact it is automatically initialized to an
+;                     empty string)
+; E_STRICT          - run-time notices, enable to have PHP suggest changes
+;                     to your code which will ensure the best interoperability
+;                     and forward compatibility of your code
+; E_CORE_ERROR      - fatal errors that occur during PHP's initial startup
+; E_CORE_WARNING    - warnings (non-fatal errors) that occur during PHP's
+;                     initial startup
+; E_COMPILE_ERROR   - fatal compile-time errors
+; E_COMPILE_WARNING - compile-time warnings (non-fatal errors)
+; E_USER_ERROR      - user-generated error message
+; E_USER_WARNING    - user-generated warning message
+; E_USER_NOTICE     - user-generated notice message
+; E_DEPRECATED      - warn about code that will not work in future versions
+;                     of PHP
+; E_USER_DEPRECATED - user-generated deprecation warnings
+;
+; Common Values:
+;   E_ALL (Show all errors, warnings and notices including coding standards.)
+;   E_ALL & ~E_NOTICE  (Show all errors, except for notices)
+;   E_ALL & ~E_NOTICE & ~E_STRICT  (Show all errors, except for notices and coding standards warnings.)
+;   E_COMPILE_ERROR|E_RECOVERABLE_ERROR|E_ERROR|E_CORE_ERROR  (Show only errors)
+; Default Value: E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
+; Development Value: E_ALL
+; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
+; http://php.net/error-reporting
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+
+; This directive controls whether or not and where PHP will output errors,
+; notices and warnings too. Error output is very useful during development, but
+; it could be very dangerous in production environments. Depending on the code
+; which is triggering the error, sensitive information could potentially leak
+; out of your application such as database usernames and passwords or worse.
+; For production environments, we recommend logging errors rather than
+; sending them to STDOUT.
+; Possible Values:
+;   Off = Do not display any errors
+;   stderr = Display errors to STDERR (affects only CGI/CLI binaries!)
+;   On or stdout = Display errors to STDOUT
+; Default Value: On
+; Development Value: On
+; Production Value: Off
+; http://php.net/display-errors
+display_errors = Off
+
+; The display of errors which occur during PHP's startup sequence are handled
+; separately from display_errors. PHP's default behavior is to suppress those
+; errors from clients. Turning the display of startup errors on can be useful in
+; debugging configuration problems. We strongly recommend you
+; set this to 'off' for production servers.
+; Default Value: Off
+; Development Value: On
+; Production Value: Off
+; http://php.net/display-startup-errors
+display_startup_errors = Off
+
+; Besides displaying errors, PHP can also log errors to locations such as a
+; server-specific log, STDERR, or a location specified by the error_log
+; directive found below. While errors should not be displayed on productions
+; servers they should still be monitored and logging is a great way to do that.
+; Default Value: Off
+; Development Value: On
+; Production Value: On
+; http://php.net/log-errors
+log_errors = On
+
+; Set maximum length of log_errors. In error_log information about the source is
+; added. The default is 1024 and 0 allows to not apply any maximum length at all.
+; http://php.net/log-errors-max-len
+log_errors_max_len = 1024
+
+; Do not log repeated messages. Repeated errors must occur in same file on same
+; line unless ignore_repeated_source is set true.
+; http://php.net/ignore-repeated-errors
+ignore_repeated_errors = Off
+
+; Ignore source of message when ignoring repeated messages. When this setting
+; is On you will not log errors with repeated messages from different files or
+; source lines.
+; http://php.net/ignore-repeated-source
+ignore_repeated_source = Off
+
+; If this parameter is set to Off, then memory leaks will not be shown (on
+; stdout or in the log). This has only effect in a debug compile, and if
+; error reporting includes E_WARNING in the allowed list
+; http://php.net/report-memleaks
+report_memleaks = On
+
+; This setting is on by default.
+;report_zend_debug = 0
+
+; Store the last error/warning message in $php_errormsg (boolean). Setting this value
+; to On can assist in debugging and is appropriate for development servers. It should
+; however be disabled on production servers.
+; Default Value: Off
+; Development Value: On
+; Production Value: Off
+; http://php.net/track-errors
+track_errors = Off
+
+; Turn off normal error reporting and emit XML-RPC error XML
+; http://php.net/xmlrpc-errors
+;xmlrpc_errors = 0
+
+; An XML-RPC faultCode
+;xmlrpc_error_number = 0
+
+; When PHP displays or logs an error, it has the capability of formatting the
+; error message as HTML for easier reading. This directive controls whether
+; the error message is formatted as HTML or not.
+; Note: This directive is hardcoded to Off for the CLI SAPI
+; Default Value: On
+; Development Value: On
+; Production value: On
+; http://php.net/html-errors
+html_errors = On
+
+; If html_errors is set to On *and* docref_root is not empty, then PHP
+; produces clickable error messages that direct to a page describing the error
+; or function causing the error in detail.
+; You can download a copy of the PHP manual from http://php.net/docs
+; and change docref_root to the base URL of your local copy including the
+; leading '/'. You must also specify the file extension being used including
+; the dot. PHP's default behavior is to leave these settings empty, in which
+; case no links to documentation are generated.
+; Note: Never use this feature for production boxes.
+; http://php.net/docref-root
+; Examples
+;docref_root = "/phpmanual/"
+
+; http://php.net/docref-ext
+;docref_ext = .html
+
+; String to output before an error message. PHP's default behavior is to leave
+; this setting blank.
+; http://php.net/error-prepend-string
+; Example:
+;error_prepend_string = "<span style='color: #ff0000'>"
+
+; String to output after an error message. PHP's default behavior is to leave
+; this setting blank.
+; http://php.net/error-append-string
+; Example:
+;error_append_string = "</span>"
+
+; Log errors to specified file. PHP's default behavior is to leave this value
+; empty.
+; http://php.net/error-log
+; Example:
+;error_log = php_errors.log
+; Log errors to syslog (Event Log on Windows).
+;error_log = syslog
+
+;windows.show_crt_warning
+; Default value: 0
+; Development value: 0
+; Production value: 0
+
+;;;;;;;;;;;;;;;;;
+; Data Handling ;
+;;;;;;;;;;;;;;;;;
+
+; The separator used in PHP generated URLs to separate arguments.
+; PHP's default setting is "&".
+; http://php.net/arg-separator.output
+; Example:
+;arg_separator.output = "&amp;"
+
+; List of separator(s) used by PHP to parse input URLs into variables.
+; PHP's default setting is "&".
+; NOTE: Every character in this directive is considered as separator!
+; http://php.net/arg-separator.input
+; Example:
+;arg_separator.input = ";&"
+
+; This directive determines which super global arrays are registered when PHP
+; starts up. G,P,C,E & S are abbreviations for the following respective super
+; globals: GET, POST, COOKIE, ENV and SERVER. There is a performance penalty
+; paid for the registration of these arrays and because ENV is not as commonly
+; used as the others, ENV is not recommended on productions servers. You
+; can still get access to the environment variables through getenv() should you
+; need to.
+; Default Value: "EGPCS"
+; Development Value: "GPCS"
+; Production Value: "GPCS";
+; http://php.net/variables-order
+variables_order = "GPCS"
+
+; This directive determines which super global data (G,P & C) should be
+; registered into the super global array REQUEST. If so, it also determines
+; the order in which that data is registered. The values for this directive
+; are specified in the same manner as the variables_order directive,
+; EXCEPT one. Leaving this value empty will cause PHP to use the value set
+; in the variables_order directive. It does not mean it will leave the super
+; globals array REQUEST empty.
+; Default Value: None
+; Development Value: "GP"
+; Production Value: "GP"
+; http://php.net/request-order
+request_order = "GP"
+
+; This directive determines whether PHP registers $argv & $argc each time it
+; runs. $argv contains an array of all the arguments passed to PHP when a script
+; is invoked. $argc contains an integer representing the number of arguments
+; that were passed when the script was invoked. These arrays are extremely
+; useful when running scripts from the command line. When this directive is
+; enabled, registering these variables consumes CPU cycles and memory each time
+; a script is executed. For performance reasons, this feature should be disabled
+; on production servers.
+; Note: This directive is hardcoded to On for the CLI SAPI
+; Default Value: On
+; Development Value: Off
+; Production Value: Off
+; http://php.net/register-argc-argv
+register_argc_argv = Off
+
+; When enabled, the ENV, REQUEST and SERVER variables are created when they're
+; first used (Just In Time) instead of when the script starts. If these
+; variables are not used within a script, having this directive on will result
+; in a performance gain. The PHP directive register_argc_argv must be disabled
+; for this directive to have any affect.
+; http://php.net/auto-globals-jit
+auto_globals_jit = On
+
+; Whether PHP will read the POST data.
+; This option is enabled by default.
+; Most likely, you won't want to disable this option globally. It causes $_POST
+; and $_FILES to always be empty; the only way you will be able to read the
+; POST data will be through the php://input stream wrapper. This can be useful
+; to proxy requests or to process the POST data in a memory efficient fashion.
+; http://php.net/enable-post-data-reading
+;enable_post_data_reading = Off
+
+; Maximum size of POST data that PHP will accept.
+; Its value may be 0 to disable the limit. It is ignored if POST data reading
+; is disabled through enable_post_data_reading.
+; http://php.net/post-max-size
+post_max_size = 8M
+
+; Automatically add files before PHP document.
+; http://php.net/auto-prepend-file
+auto_prepend_file =
+
+; Automatically add files after PHP document.
+; http://php.net/auto-append-file
+auto_append_file =
+
+; By default, PHP will output a media type using the Content-Type header. To
+; disable this, simply set it to be empty.
+;
+; PHP's built-in default media type is set to text/html.
+; http://php.net/default-mimetype
+default_mimetype = "text/html"
+
+; PHP's default character set is set to UTF-8.
+; http://php.net/default-charset
+default_charset = "UTF-8"
+
+; PHP internal character encoding is set to empty.
+; If empty, default_charset is used.
+; http://php.net/internal-encoding
+;internal_encoding =
+
+; PHP input character encoding is set to empty.
+; If empty, default_charset is used.
+; http://php.net/input-encoding
+;input_encoding =
+
+; PHP output character encoding is set to empty.
+; If empty, default_charset is used.
+; See also output_buffer.
+; http://php.net/output-encoding
+;output_encoding =
+
+; Always populate the $HTTP_RAW_POST_DATA variable. PHP's default behavior is
+; to disable this feature and it will be removed in a future version.
+; If post reading is disabled through enable_post_data_reading,
+; $HTTP_RAW_POST_DATA is *NOT* populated.
+; http://php.net/always-populate-raw-post-data
+;always_populate_raw_post_data = -1
+
+;;;;;;;;;;;;;;;;;;;;;;;;;
+; Paths and Directories ;
+;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; UNIX: "/path1:/path2"
+;include_path = ".:/php/includes"
+;
+; Windows: "\path1;\path2"
+;include_path = ".;c:\php\includes"
+;
+; PHP's default setting for include_path is ".;/path/to/php/pear"
+; http://php.net/include-path
+
+; The root of the PHP pages, used only if nonempty.
+; if PHP was not compiled with FORCE_REDIRECT, you SHOULD set doc_root
+; if you are running php as a CGI under any web server (other than IIS)
+; see documentation for security issues.  The alternate is to use the
+; cgi.force_redirect configuration below
+; http://php.net/doc-root
+doc_root =
+
+; The directory under which PHP opens the script using /~username used only
+; if nonempty.
+; http://php.net/user-dir
+user_dir =
+
+; Directory in which the loadable extensions (modules) reside.
+; http://php.net/extension-dir
+extension_dir = "/usr/local/zend/php/5.6/lib/ext"
+; On windows:
+;extension_dir = "/usr/local/zend/php/5.6/lib/ext"
+
+; Directory where the temporary files should be placed.
+; Defaults to the system default (see sys_get_temp_dir)
+; sys_temp_dir = "/tmp"
+
+; Whether or not to enable the dl() function.  The dl() function does NOT work
+; properly in multithreaded servers, such as IIS or Zeus, and is automatically
+; disabled on them.
+; http://php.net/enable-dl
+enable_dl = Off
+
+; cgi.force_redirect is necessary to provide security running PHP as a CGI under
+; most web servers.  Left undefined, PHP turns this on by default.  You can
+; turn it off here AT YOUR OWN RISK
+; **You CAN safely turn this off for IIS, in fact, you MUST.**
+; http://php.net/cgi.force-redirect
+;cgi.force_redirect = 1
+
+; if cgi.nph is enabled it will force cgi to always sent Status: 200 with
+; every request. PHP's default behavior is to disable this feature.
+;cgi.nph = 1
+
+; if cgi.force_redirect is turned on, and you are not running under Apache or Netscape
+; (iPlanet) web servers, you MAY need to set an environment variable name that PHP
+; will look for to know it is OK to continue execution.  Setting this variable MAY
+; cause security issues, KNOW WHAT YOU ARE DOING FIRST.
+; http://php.net/cgi.redirect-status-env
+;cgi.redirect_status_env =
+
+; cgi.fix_pathinfo provides *real* PATH_INFO/PATH_TRANSLATED support for CGI.  PHP's
+; previous behaviour was to set PATH_TRANSLATED to SCRIPT_FILENAME, and to not grok
+; what PATH_INFO is.  For more information on PATH_INFO, see the cgi specs.  Setting
+; this to 1 will cause PHP CGI to fix its paths to conform to the spec.  A setting
+; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
+; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
+; http://php.net/cgi.fix-pathinfo
+;cgi.fix_pathinfo=1
+
+; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
+; of the web tree and people will not be able to circumvent .htaccess security.
+; http://php.net/cgi.dicard-path
+;cgi.discard_path=1
+
+; FastCGI under IIS (on WINNT based OS) supports the ability to impersonate
+; security tokens of the calling client.  This allows IIS to define the
+; security context that the request runs under.  mod_fastcgi under Apache
+; does not currently support this feature (03/17/2002)
+; Set to 1 if running under IIS.  Default is zero.
+; http://php.net/fastcgi.impersonate
+;fastcgi.impersonate = 1
+
+; Disable logging through FastCGI connection. PHP's default behavior is to enable
+; this feature.
+;fastcgi.logging = 0
+
+; cgi.rfc2616_headers configuration option tells PHP what type of headers to
+; use when sending HTTP response code. If set to 0, PHP sends Status: header that
+; is supported by Apache. When this option is set to 1, PHP will send
+; RFC2616 compliant header.
+; Default is zero.
+; http://php.net/cgi.rfc2616-headers
+;cgi.rfc2616_headers = 0
+
+; cgi.check_shebang_line controls whether CGI PHP checks for line starting with #!
+; (shebang) at the top of the running script. This line might be needed if the
+; script support running both as stand-alone script and via PHP CGI<. PHP in CGI
+; mode skips this line and ignores its content if this directive is turned on.
+; http://php.net/cgi.check-shebang-line
+;cgi.check_shebang_line=1
+
+;;;;;;;;;;;;;;;;
+; File Uploads ;
+;;;;;;;;;;;;;;;;
+
+; Whether to allow HTTP file uploads.
+; http://php.net/file-uploads
+file_uploads = On
+
+; Temporary directory for HTTP uploaded files (will use system default if not
+; specified).
+; http://php.net/upload-tmp-dir
+;upload_tmp_dir =
+
+; Maximum allowed size for uploaded files.
+; http://php.net/upload-max-filesize
+upload_max_filesize = 2M
+
+; Maximum number of files that can be uploaded via a single request
+max_file_uploads = 20
+
+;;;;;;;;;;;;;;;;;;
+; Fopen wrappers ;
+;;;;;;;;;;;;;;;;;;
+
+; Whether to allow the treatment of URLs (like http:// or ftp://) as files.
+; http://php.net/allow-url-fopen
+allow_url_fopen = On
+
+; Whether to allow include/require to open URLs (like http:// or ftp://) as files.
+; http://php.net/allow-url-include
+allow_url_include = Off
+
+; Define the anonymous ftp password (your email address). PHP's default setting
+; for this is empty.
+; http://php.net/from
+;from="john@doe.com"
+
+; Define the User-Agent string. PHP's default setting for this is empty.
+; http://php.net/user-agent
+;user_agent="PHP"
+
+; Default timeout for socket based streams (seconds)
+; http://php.net/default-socket-timeout
+default_socket_timeout = 60
+
+; If your scripts have to deal with files from Macintosh systems,
+; or you are running on a Mac and need to deal with files from
+; unix or win32 systems, setting this flag will cause PHP to
+; automatically detect the EOL character in those files so that
+; fgets() and file() will work regardless of the source of the file.
+; http://php.net/auto-detect-line-endings
+;auto_detect_line_endings = Off
+
+;;;;;;;;;;;;;;;;;;;;;;
+; Dynamic Extensions ;
+;;;;;;;;;;;;;;;;;;;;;;
+
+; If you wish to have an extension loaded automatically, use the following
+; syntax:
+;
+;   extension=modulename.extension
+;
+; For example, on Windows:
+;
+;   extension=msql.dll
+;
+; ... or under UNIX:
+;
+;   extension=msql.so
+;
+; ... or with a path:
+;
+;   extension=/path/to/extension/msql.so
+;
+; If you only provide the name of the extension, PHP will look for it in its
+; default extension directory.
+;
+; Windows Extensions
+; Note that ODBC support is built in, so no dll is needed for it.
+; Note that many DLL files are located in the extensions/ (PHP 4) ext/ (PHP 5)
+; extension folders as well as the separate PECL DLL download (PHP 5).
+; Be sure to appropriately set the extension_dir directive.
+;
+;extension=php_bz2.dll
+;extension=php_curl.dll
+;extension=php_fileinfo.dll
+;extension=php_gd2.dll
+;extension=php_gettext.dll
+;extension=php_gmp.dll
+;extension=php_intl.dll
+;extension=php_imap.dll
+;extension=php_interbase.dll
+;extension=php_ldap.dll
+;extension=php_mbstring.dll
+;extension=php_exif.dll      ; Must be after mbstring as it depends on it
+;extension=php_mysql.dll
+;extension=php_mysqli.dll
+;extension=php_oci8_12c.dll  ; Use with Oracle Database 12c Instant Client
+;extension=php_openssl.dll
+;extension=php_pdo_firebird.dll
+;extension=php_pdo_mysql.dll
+;extension=php_pdo_oci.dll
+;extension=php_pdo_odbc.dll
+;extension=php_pdo_pgsql.dll
+;extension=php_pdo_sqlite.dll
+;extension=php_pgsql.dll
+;extension=php_shmop.dll
+
+; The MIBS data available in the PHP distribution must be installed. 
+; See http://www.php.net/manual/en/snmp.installation.php 
+;extension=php_snmp.dll
+
+;extension=php_soap.dll
+;extension=php_sockets.dll
+;extension=php_sqlite3.dll
+;extension=php_sybase_ct.dll
+;extension=php_tidy.dll
+;extension=php_xmlrpc.dll
+;extension=php_xsl.dll
+
+;;;;;;;;;;;;;;;;;;;
+; Module Settings ;
+;;;;;;;;;;;;;;;;;;;
+
+[CLI Server]
+; Whether the CLI web server uses ANSI color coding in its terminal output.
+cli_server.color = On
+
+[Date]
+; Defines the default timezone used by the date functions
+; http://php.net/date.timezone
+date.timezone = Europe/London
+
+; http://php.net/date.default-latitude
+;date.default_latitude = 31.7667
+
+; http://php.net/date.default-longitude
+;date.default_longitude = 35.2333
+
+; http://php.net/date.sunrise-zenith
+;date.sunrise_zenith = 90.583333
+
+; http://php.net/date.sunset-zenith
+;date.sunset_zenith = 90.583333
+
+[filter]
+; http://php.net/filter.default
+;filter.default = unsafe_raw
+
+; http://php.net/filter.default-flags
+;filter.default_flags =
+
+[iconv]
+; Use of this INI entry is deprecated, use global input_encoding instead.
+; If empty, default_charset or input_encoding or iconv.input_encoding is used.
+; The precedence is: default_charset < intput_encoding < iconv.input_encoding
+;iconv.input_encoding =
+
+; Use of this INI entry is deprecated, use global internal_encoding instead.
+; If empty, default_charset or internal_encoding or iconv.internal_encoding is used.
+; The precedence is: default_charset < internal_encoding < iconv.internal_encoding
+;iconv.internal_encoding =
+
+; Use of this INI entry is deprecated, use global output_encoding instead.
+; If empty, default_charset or output_encoding or iconv.output_encoding is used.
+; The precedence is: default_charset < output_encoding < iconv.output_encoding
+; To use an output encoding conversion, iconv's output handler must be set
+; otherwise output encoding conversion cannot be performed.
+;iconv.output_encoding =
+
+[intl]
+;intl.default_locale =
+; This directive allows you to produce PHP errors when some error
+; happens within intl functions. The value is the level of the error produced.
+; Default is 0, which does not produce any errors.
+;intl.error_level = E_WARNING
+;intl.use_exceptions = 0
+
+[sqlite3]
+; Directory pointing to SQLite3 extensions
+; http://php.net/sqlite3.extension-dir
+;sqlite3.extension_dir =
+
+; SQLite defensive mode flag (only available from SQLite 3.26+)
+; When the defensive flag is enabled, language features that allow ordinary
+; SQL to deliberately corrupt the database file are disabled. This forbids
+; writing directly to the schema, shadow tables (eg. FTS data tables), or
+; the sqlite_dbpage virtual table.
+; https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
+; (for older SQLite versions, this flag has no use)
+sqlite3.defensive = 1
+
+[Pcre]
+;PCRE library backtracking limit.
+; http://php.net/pcre.backtrack-limit
+;pcre.backtrack_limit=100000
+
+;PCRE library recursion limit.
+;Please note that if you set this value to a high number you may consume all
+;the available process stack and eventually crash PHP (due to reaching the
+;stack size limit imposed by the Operating System).
+; http://php.net/pcre.recursion-limit
+;pcre.recursion_limit=100000
+
+[Pdo]
+; Whether to pool ODBC connections. Can be one of "strict", "relaxed" or "off"
+; http://php.net/pdo-odbc.connection-pooling
+;pdo_odbc.connection_pooling=strict
+
+;pdo_odbc.db2_instance_name
+
+[Pdo_mysql]
+; If mysqlnd is used: Number of cache slots for the internal result set cache
+; http://php.net/pdo_mysql.cache_size
+pdo_mysql.cache_size = 2000
+
+; Default socket name for local MySQL connects.  If empty, uses the built-in
+; MySQL defaults.
+; http://php.net/pdo_mysql.default-socket
+pdo_mysql.default_socket=
+
+[Phar]
+; http://php.net/phar.readonly
+;phar.readonly = On
+
+; http://php.net/phar.require-hash
+;phar.require_hash = On
+
+;phar.cache_list =
+
+[mail function]
+; For Win32 only.
+; http://php.net/smtp
+;SMTP = localhost
+; http://php.net/smtp-port
+;smtp_port = 25
+
+; For Win32 only.
+; http://php.net/sendmail-from
+;sendmail_from = me@example.com
+
+; For Unix only.  You may supply arguments as well (default: "sendmail -t -i").
+; http://php.net/sendmail-path
+sendmail_path = /usr/sbin/sendmail -t -i
+
+; Force the addition of the specified parameters to be passed as extra parameters
+; to the sendmail binary. These parameters will always replace the value of
+; the 5th parameter to mail().
+;mail.force_extra_parameters =
+
+; Add X-PHP-Originating-Script: that will include uid of the script followed by the filename
+mail.add_x_header = On
+
+; The path to a log file that will log all mail() calls. Log entries include
+; the full path of the script, line number, To address and headers.
+;mail.log =
+; Log mail to syslog (Event Log on Windows).
+;mail.log = syslog
+
+[SQL]
+; http://php.net/sql.safe-mode
+sql.safe_mode = Off
+
+[ODBC]
+; http://php.net/odbc.default-db
+;odbc.default_db    =  Not yet implemented
+
+; http://php.net/odbc.default-user
+;odbc.default_user  =  Not yet implemented
+
+; http://php.net/odbc.default-pw
+;odbc.default_pw    =  Not yet implemented
+
+; Controls the ODBC cursor model.
+; Default: SQL_CURSOR_STATIC (default).
+;odbc.default_cursortype
+
+; Allow or prevent persistent links.
+; http://php.net/odbc.allow-persistent
+odbc.allow_persistent = On
+
+; Check that a connection is still valid before reuse.
+; http://php.net/odbc.check-persistent
+odbc.check_persistent = On
+
+; Maximum number of persistent links.  -1 means no limit.
+; http://php.net/odbc.max-persistent
+odbc.max_persistent = -1
+
+; Maximum number of links (persistent + non-persistent).  -1 means no limit.
+; http://php.net/odbc.max-links
+odbc.max_links = -1
+
+; Handling of LONG fields.  Returns number of bytes to variables.  0 means
+; passthru.
+; http://php.net/odbc.defaultlrl
+odbc.defaultlrl = 4096
+
+; Handling of binary data.  0 means passthru, 1 return as is, 2 convert to char.
+; See the documentation on odbc_binmode and odbc_longreadlen for an explanation
+; of odbc.defaultlrl and odbc.defaultbinmode
+; http://php.net/odbc.defaultbinmode
+odbc.defaultbinmode = 1
+
+;birdstep.max_links = -1
+
+[Interbase]
+; Allow or prevent persistent links.
+ibase.allow_persistent = 1
+
+; Maximum number of persistent links.  -1 means no limit.
+ibase.max_persistent = -1
+
+; Maximum number of links (persistent + non-persistent).  -1 means no limit.
+ibase.max_links = -1
+
+; Default database name for ibase_connect().
+;ibase.default_db =
+
+; Default username for ibase_connect().
+;ibase.default_user =
+
+; Default password for ibase_connect().
+;ibase.default_password =
+
+; Default charset for ibase_connect().
+;ibase.default_charset =
+
+; Default timestamp format.
+ibase.timestampformat = "%Y-%m-%d %H:%M:%S"
+
+; Default date format.
+ibase.dateformat = "%Y-%m-%d"
+
+; Default time format.
+ibase.timeformat = "%H:%M:%S"
+
+[MySQL]
+; Allow accessing, from PHP's perspective, local files with LOAD DATA statements
+; http://php.net/mysql.allow_local_infile
+mysql.allow_local_infile = On
+
+; Allow or prevent persistent links.
+; http://php.net/mysql.allow-persistent
+mysql.allow_persistent = On
+
+; If mysqlnd is used: Number of cache slots for the internal result set cache
+; http://php.net/mysql.cache_size
+mysql.cache_size = 2000
+
+; Maximum number of persistent links.  -1 means no limit.
+; http://php.net/mysql.max-persistent
+mysql.max_persistent = -1
+
+; Maximum number of links (persistent + non-persistent).  -1 means no limit.
+; http://php.net/mysql.max-links
+mysql.max_links = -1
+
+; Default port number for mysql_connect().  If unset, mysql_connect() will use
+; the $MYSQL_TCP_PORT or the mysql-tcp entry in /etc/services or the
+; compile-time value defined MYSQL_PORT (in that order).  Win32 will only look
+; at MYSQL_PORT.
+; http://php.net/mysql.default-port
+mysql.default_port =
+
+; Default socket name for local MySQL connects.  If empty, uses the built-in
+; MySQL defaults.
+; http://php.net/mysql.default-socket
+mysql.default_socket =
+
+; Default host for mysql_connect() (doesn't apply in safe mode).
+; http://php.net/mysql.default-host
+mysql.default_host =
+
+; Default user for mysql_connect() (doesn't apply in safe mode).
+; http://php.net/mysql.default-user
+mysql.default_user =
+
+; Default password for mysql_connect() (doesn't apply in safe mode).
+; Note that this is generally a *bad* idea to store passwords in this file.
+; *Any* user with PHP access can run 'echo get_cfg_var("mysql.default_password")
+; and reveal this password!  And of course, any users with read access to this
+; file will be able to reveal the password as well.
+; http://php.net/mysql.default-password
+mysql.default_password =
+
+; Maximum time (in seconds) for connect timeout. -1 means no limit
+; http://php.net/mysql.connect-timeout
+mysql.connect_timeout = 60
+
+; Trace mode. When trace_mode is active (=On), warnings for table/index scans and
+; SQL-Errors will be displayed.
+; http://php.net/mysql.trace-mode
+mysql.trace_mode = Off
+
+[MySQLi]
+
+; Maximum number of persistent links.  -1 means no limit.
+; http://php.net/mysqli.max-persistent
+mysqli.max_persistent = -1
+
+; Allow accessing, from PHP's perspective, local files with LOAD DATA statements
+; http://php.net/mysqli.allow_local_infile
+;mysqli.allow_local_infile = On
+
+; Allow or prevent persistent links.
+; http://php.net/mysqli.allow-persistent
+mysqli.allow_persistent = On
+
+; Maximum number of links.  -1 means no limit.
+; http://php.net/mysqli.max-links
+mysqli.max_links = -1
+
+; If mysqlnd is used: Number of cache slots for the internal result set cache
+; http://php.net/mysqli.cache_size
+mysqli.cache_size = 2000
+
+; Default port number for mysqli_connect().  If unset, mysqli_connect() will use
+; the $MYSQL_TCP_PORT or the mysql-tcp entry in /etc/services or the
+; compile-time value defined MYSQL_PORT (in that order).  Win32 will only look
+; at MYSQL_PORT.
+; http://php.net/mysqli.default-port
+mysqli.default_port = 3306
+
+; Default socket name for local MySQL connects.  If empty, uses the built-in
+; MySQL defaults.
+; http://php.net/mysqli.default-socket
+mysqli.default_socket =
+
+; Default host for mysql_connect() (doesn't apply in safe mode).
+; http://php.net/mysqli.default-host
+mysqli.default_host =
+
+; Default user for mysql_connect() (doesn't apply in safe mode).
+; http://php.net/mysqli.default-user
+mysqli.default_user =
+
+; Default password for mysqli_connect() (doesn't apply in safe mode).
+; Note that this is generally a *bad* idea to store passwords in this file.
+; *Any* user with PHP access can run 'echo get_cfg_var("mysqli.default_pw")
+; and reveal this password!  And of course, any users with read access to this
+; file will be able to reveal the password as well.
+; http://php.net/mysqli.default-pw
+mysqli.default_pw =
+
+; Allow or prevent reconnect
+mysqli.reconnect = Off
+
+[mysqlnd]
+; Enable / Disable collection of general statistics by mysqlnd which can be
+; used to tune and monitor MySQL operations.
+; http://php.net/mysqlnd.collect_statistics
+mysqlnd.collect_statistics = On
+
+; Enable / Disable collection of memory usage statistics by mysqlnd which can be
+; used to tune and monitor MySQL operations.
+; http://php.net/mysqlnd.collect_memory_statistics
+mysqlnd.collect_memory_statistics = Off
+
+; Records communication from all extensions using mysqlnd to the specified log
+; file.
+; http://php.net/mysqlnd.debug
+;mysqlnd.debug =
+
+; Defines which queries will be logged.
+; http://php.net/mysqlnd.log_mask
+;mysqlnd.log_mask = 0
+
+; Default size of the mysqlnd memory pool, which is used by result sets.
+; http://php.net/mysqlnd.mempool_default_size
+;mysqlnd.mempool_default_size = 16000
+
+; Size of a pre-allocated buffer used when sending commands to MySQL in bytes.
+; http://php.net/mysqlnd.net_cmd_buffer_size
+;mysqlnd.net_cmd_buffer_size = 2048
+
+; Size of a pre-allocated buffer used for reading data sent by the server in
+; bytes.
+; http://php.net/mysqlnd.net_read_buffer_size
+;mysqlnd.net_read_buffer_size = 32768
+
+; Timeout for network requests in seconds.
+; http://php.net/mysqlnd.net_read_timeout
+;mysqlnd.net_read_timeout = 31536000
+
+; SHA-256 Authentication Plugin related. File with the MySQL server public RSA
+; key.
+; http://php.net/mysqlnd.sha256_server_public_key
+;mysqlnd.sha256_server_public_key =
+
+[OCI8]
+
+; Connection: Enables privileged connections using external
+; credentials (OCI_SYSOPER, OCI_SYSDBA)
+; http://php.net/oci8.privileged-connect
+;oci8.privileged_connect = Off
+
+; Connection: The maximum number of persistent OCI8 connections per
+; process. Using -1 means no limit.
+; http://php.net/oci8.max-persistent
+;oci8.max_persistent = -1
+
+; Connection: The maximum number of seconds a process is allowed to
+; maintain an idle persistent connection. Using -1 means idle
+; persistent connections will be maintained forever.
+; http://php.net/oci8.persistent-timeout
+;oci8.persistent_timeout = -1
+
+; Connection: The number of seconds that must pass before issuing a
+; ping during oci_pconnect() to check the connection validity. When
+; set to 0, each oci_pconnect() will cause a ping. Using -1 disables
+; pings completely.
+; http://php.net/oci8.ping-interval
+;oci8.ping_interval = 60
+
+; Connection: Set this to a user chosen connection class to be used
+; for all pooled server requests with Oracle 11g Database Resident
+; Connection Pooling (DRCP).  To use DRCP, this value should be set to
+; the same string for all web servers running the same application,
+; the database pool must be configured, and the connection string must
+; specify to use a pooled server.
+;oci8.connection_class =
+
+; High Availability: Using On lets PHP receive Fast Application
+; Notification (FAN) events generated when a database node fails. The
+; database must also be configured to post FAN events.
+;oci8.events = Off
+
+; Tuning: This option enables statement caching, and specifies how
+; many statements to cache. Using 0 disables statement caching.
+; http://php.net/oci8.statement-cache-size
+;oci8.statement_cache_size = 20
+
+; Tuning: Enables statement prefetching and sets the default number of
+; rows that will be fetched automatically after statement execution.
+; http://php.net/oci8.default-prefetch
+;oci8.default_prefetch = 100
+
+; Compatibility. Using On means oci_close() will not close
+; oci_connect() and oci_new_connect() connections.
+; http://php.net/oci8.old-oci-close-semantics
+;oci8.old_oci_close_semantics = Off
+
+[PostgreSQL]
+; Allow or prevent persistent links.
+; http://php.net/pgsql.allow-persistent
+pgsql.allow_persistent = On
+
+; Detect broken persistent links always with pg_pconnect().
+; Auto reset feature requires a little overheads.
+; http://php.net/pgsql.auto-reset-persistent
+pgsql.auto_reset_persistent = Off
+
+; Maximum number of persistent links.  -1 means no limit.
+; http://php.net/pgsql.max-persistent
+pgsql.max_persistent = -1
+
+; Maximum number of links (persistent+non persistent).  -1 means no limit.
+; http://php.net/pgsql.max-links
+pgsql.max_links = -1
+
+; Ignore PostgreSQL backends Notice message or not.
+; Notice message logging require a little overheads.
+; http://php.net/pgsql.ignore-notice
+pgsql.ignore_notice = 0
+
+; Log PostgreSQL backends Notice message or not.
+; Unless pgsql.ignore_notice=0, module cannot log notice message.
+; http://php.net/pgsql.log-notice
+pgsql.log_notice = 0
+
+[Sybase-CT]
+; Allow or prevent persistent links.
+; http://php.net/sybct.allow-persistent
+sybct.allow_persistent = On
+
+; Maximum number of persistent links.  -1 means no limit.
+; http://php.net/sybct.max-persistent
+sybct.max_persistent = -1
+
+; Maximum number of links (persistent + non-persistent).  -1 means no limit.
+; http://php.net/sybct.max-links
+sybct.max_links = -1
+
+; Minimum server message severity to display.
+; http://php.net/sybct.min-server-severity
+sybct.min_server_severity = 10
+
+; Minimum client message severity to display.
+; http://php.net/sybct.min-client-severity
+sybct.min_client_severity = 10
+
+; Set per-context timeout
+; http://php.net/sybct.timeout
+;sybct.timeout=
+
+;sybct.packet_size
+
+; The maximum time in seconds to wait for a connection attempt to succeed before returning failure.
+; Default: one minute
+;sybct.login_timeout=
+
+; The name of the host you claim to be connecting from, for display by sp_who.
+; Default: none
+;sybct.hostname=
+
+; Allows you to define how often deadlocks are to be retried. -1 means "forever".
+; Default: 0
+;sybct.deadlock_retry_count=
+
+[bcmath]
+; Number of decimal digits for all bcmath functions.
+; http://php.net/bcmath.scale
+bcmath.scale = 0
+
+[browscap]
+; http://php.net/browscap
+;browscap = extra/browscap.ini
+
+[Session]
+; Handler used to store/retrieve data.
+; http://php.net/session.save-handler
+session.save_handler = files
+
+; Argument passed to save_handler.  In the case of files, this is the path
+; where data files are stored. Note: Windows users have to change this
+; variable in order to use PHP's session functions.
+;
+; The path can be defined as:
+;
+;     session.save_path = "N;/path"
+;
+; where N is an integer.  Instead of storing all the session files in
+; /path, what this will do is use subdirectories N-levels deep, and
+; store the session data in those directories.  This is useful if
+; your OS has problems with many files in one directory, and is
+; a more efficient layout for servers that handle many sessions.
+;
+; NOTE 1: PHP will not create this directory structure automatically.
+;         You can use the script in the ext/session dir for that purpose.
+; NOTE 2: See the section on garbage collection below if you choose to
+;         use subdirectories for session storage
+;
+; The file storage module creates files using mode 600 by default.
+; You can change that by using
+;
+;     session.save_path = "N;MODE;/path"
+;
+; where MODE is the octal representation of the mode. Note that this
+; does not overwrite the process's umask.
+; http://php.net/session.save-path
+;session.save_path = "/tmp"
+
+; Whether to use strict session mode.
+; Strict session mode does not accept uninitialized session ID and regenerate
+; session ID if browser sends uninitialized session ID. Strict mode protects
+; applications from session fixation via session adoption vulnerability. It is
+; disabled by default for maximum compatibility, but enabling it is encouraged.
+; https://wiki.php.net/rfc/strict_sessions
+session.use_strict_mode = 0
+
+; Whether to use cookies.
+; http://php.net/session.use-cookies
+session.use_cookies = 1
+
+; http://php.net/session.cookie-secure
+;session.cookie_secure =
+
+; This option forces PHP to fetch and use a cookie for storing and maintaining
+; the session id. We encourage this operation as it's very helpful in combating
+; session hijacking when not specifying and managing your own session id. It is
+; not the be-all and end-all of session hijacking defense, but it's a good start.
+; http://php.net/session.use-only-cookies
+session.use_only_cookies = 1
+
+; Name of the session (used as cookie name).
+; http://php.net/session.name
+session.name = PHPSESSID
+
+; Initialize session on request startup.
+; http://php.net/session.auto-start
+session.auto_start = 0
+
+; Lifetime in seconds of cookie or, if 0, until browser is restarted.
+; http://php.net/session.cookie-lifetime
+session.cookie_lifetime = 0
+
+; The path for which the cookie is valid.
+; http://php.net/session.cookie-path
+session.cookie_path = /
+
+; The domain for which the cookie is valid.
+; http://php.net/session.cookie-domain
+session.cookie_domain =
+
+; Whether or not to add the httpOnly flag to the cookie, which makes it inaccessible to browser scripting languages such as JavaScript.
+; http://php.net/session.cookie-httponly
+session.cookie_httponly =
+
+; Handler used to serialize data.  php is the standard serializer of PHP.
+; http://php.net/session.serialize-handler
+session.serialize_handler = php
+
+; Defines the probability that the 'garbage collection' process is started
+; on every session initialization. The probability is calculated by using
+; gc_probability/gc_divisor. Where session.gc_probability is the numerator
+; and gc_divisor is the denominator in the equation. Setting this value to 1
+; when the session.gc_divisor value is 100 will give you approximately a 1% chance
+; the gc will run on any give request.
+; Default Value: 1
+; Development Value: 1
+; Production Value: 1
+; http://php.net/session.gc-probability
+session.gc_probability = 1
+
+; Defines the probability that the 'garbage collection' process is started on every
+; session initialization. The probability is calculated by using the following equation:
+; gc_probability/gc_divisor. Where session.gc_probability is the numerator and
+; session.gc_divisor is the denominator in the equation. Setting this value to 1
+; when the session.gc_divisor value is 100 will give you approximately a 1% chance
+; the gc will run on any give request. Increasing this value to 1000 will give you
+; a 0.1% chance the gc will run on any give request. For high volume production servers,
+; this is a more efficient approach.
+; Default Value: 100
+; Development Value: 1000
+; Production Value: 1000
+; http://php.net/session.gc-divisor
+session.gc_divisor = 1000
+
+; After this number of seconds, stored data will be seen as 'garbage' and
+; cleaned up by the garbage collection process.
+; http://php.net/session.gc-maxlifetime
+session.gc_maxlifetime = 1440
+
+; NOTE: If you are using the subdirectory option for storing session files
+;       (see session.save_path above), then garbage collection does *not*
+;       happen automatically.  You will need to do your own garbage
+;       collection through a shell script, cron entry, or some other method.
+;       For example, the following script would is the equivalent of
+;       setting session.gc_maxlifetime to 1440 (1440 seconds = 24 minutes):
+;          find /path/to/sessions -cmin +24 -type f | xargs rm
+
+; Check HTTP Referer to invalidate externally stored URLs containing ids.
+; HTTP_REFERER has to contain this substring for the session to be
+; considered as valid.
+; http://php.net/session.referer-check
+session.referer_check =
+
+; How many bytes to read from the file.
+; http://php.net/session.entropy-length
+;session.entropy_length = 32
+
+; Specified here to create the session id.
+; http://php.net/session.entropy-file
+; Defaults to /dev/urandom
+; On systems that don't have /dev/urandom but do have /dev/arandom, this will default to /dev/arandom
+; If neither are found at compile time, the default is no entropy file.
+; On windows, setting the entropy_length setting will activate the
+; Windows random source (using the CryptoAPI)
+;session.entropy_file = /dev/urandom
+
+; Set to {nocache,private,public,} to determine HTTP caching aspects
+; or leave this empty to avoid sending anti-caching headers.
+; http://php.net/session.cache-limiter
+session.cache_limiter = nocache
+
+; Document expires after n minutes.
+; http://php.net/session.cache-expire
+session.cache_expire = 180
+
+; trans sid support is disabled by default.
+; Use of trans sid may risk your users' security.
+; Use this option with caution.
+; - User may send URL contains active session ID
+;   to other person via. email/irc/etc.
+; - URL that contains active session ID may be stored
+;   in publicly accessible computer.
+; - User may access your site with the same session ID
+;   always using URL stored in browser's history or bookmarks.
+; http://php.net/session.use-trans-sid
+session.use_trans_sid = 0
+
+; Select a hash function for use in generating session ids.
+; Possible Values
+;   0  (MD5 128 bits)
+;   1  (SHA-1 160 bits)
+; This option may also be set to the name of any hash function supported by
+; the hash extension. A list of available hashes is returned by the hash_algos()
+; function.
+; http://php.net/session.hash-function
+session.hash_function = 0
+
+; Define how many bits are stored in each character when converting
+; the binary hash data to something readable.
+; Possible values:
+;   4  (4 bits: 0-9, a-f)
+;   5  (5 bits: 0-9, a-v)
+;   6  (6 bits: 0-9, a-z, A-Z, "-", ",")
+; Default Value: 4
+; Development Value: 5
+; Production Value: 5
+; http://php.net/session.hash-bits-per-character
+session.hash_bits_per_character = 5
+
+; The URL rewriter will look for URLs in a defined set of HTML tags.
+; form/fieldset are special; if you include them here, the rewriter will
+; add a hidden <input> field with the info which is otherwise appended
+; to URLs.  If you want XHTML conformity, remove the form entry.
+; Note that all valid entries require a "=", even if no value follows.
+; Default Value: "a=href,area=href,frame=src,form=,fieldset="
+; Development Value: "a=href,area=href,frame=src,input=src,form=fakeentry"
+; Production Value: "a=href,area=href,frame=src,input=src,form=fakeentry"
+; http://php.net/url-rewriter.tags
+url_rewriter.tags = "a=href,area=href,frame=src,input=src,form=fakeentry"
+
+; Enable upload progress tracking in $_SESSION
+; Default Value: On
+; Development Value: On
+; Production Value: On
+; http://php.net/session.upload-progress.enabled
+;session.upload_progress.enabled = On
+
+; Cleanup the progress information as soon as all POST data has been read
+; (i.e. upload completed).
+; Default Value: On
+; Development Value: On
+; Production Value: On
+; http://php.net/session.upload-progress.cleanup
+;session.upload_progress.cleanup = On
+
+; A prefix used for the upload progress key in $_SESSION
+; Default Value: "upload_progress_"
+; Development Value: "upload_progress_"
+; Production Value: "upload_progress_"
+; http://php.net/session.upload-progress.prefix
+;session.upload_progress.prefix = "upload_progress_"
+
+; The index name (concatenated with the prefix) in $_SESSION
+; containing the upload progress information
+; Default Value: "PHP_SESSION_UPLOAD_PROGRESS"
+; Development Value: "PHP_SESSION_UPLOAD_PROGRESS"
+; Production Value: "PHP_SESSION_UPLOAD_PROGRESS"
+; http://php.net/session.upload-progress.name
+;session.upload_progress.name = "PHP_SESSION_UPLOAD_PROGRESS"
+
+; How frequently the upload progress should be updated.
+; Given either in percentages (per-file), or in bytes
+; Default Value: "1%"
+; Development Value: "1%"
+; Production Value: "1%"
+; http://php.net/session.upload-progress.freq
+;session.upload_progress.freq =  "1%"
+
+; The minimum delay between updates, in seconds
+; Default Value: 1
+; Development Value: 1
+; Production Value: 1
+; http://php.net/session.upload-progress.min-freq
+;session.upload_progress.min_freq = "1"
+
+[MSSQL]
+; Allow or prevent persistent links.
+mssql.allow_persistent = On
+
+; Maximum number of persistent links.  -1 means no limit.
+mssql.max_persistent = -1
+
+; Maximum number of links (persistent+non persistent).  -1 means no limit.
+mssql.max_links = -1
+
+; Minimum error severity to display.
+mssql.min_error_severity = 10
+
+; Minimum message severity to display.
+mssql.min_message_severity = 10
+
+; Compatibility mode with old versions of PHP 3.0.
+mssql.compatibility_mode = Off
+
+; Connect timeout
+;mssql.connect_timeout = 5
+
+; Query timeout
+;mssql.timeout = 60
+
+; Valid range 0 - 2147483647.  Default = 4096.
+;mssql.textlimit = 4096
+
+; Valid range 0 - 2147483647.  Default = 4096.
+;mssql.textsize = 4096
+
+; Limits the number of records in each batch.  0 = all records in one batch.
+;mssql.batchsize = 0
+
+; Specify how datetime and datetim4 columns are returned
+; On => Returns data converted to SQL server settings
+; Off => Returns values as YYYY-MM-DD hh:mm:ss
+;mssql.datetimeconvert = On
+
+; Use NT authentication when connecting to the server
+mssql.secure_connection = Off
+
+; Specify max number of processes. -1 = library default
+; msdlib defaults to 25
+; FreeTDS defaults to 4096
+;mssql.max_procs = -1
+
+; Specify client character set.
+; If empty or not set the client charset from freetds.conf is used
+; This is only used when compiled with FreeTDS
+;mssql.charset = "ISO-8859-1"
+
+[Assertion]
+; Assert(expr); active by default.
+; http://php.net/assert.active
+;assert.active = On
+
+; Issue a PHP warning for each failed assertion.
+; http://php.net/assert.warning
+;assert.warning = On
+
+; Don't bail out by default.
+; http://php.net/assert.bail
+;assert.bail = Off
+
+; User-function to be called if an assertion fails.
+; http://php.net/assert.callback
+;assert.callback = 0
+
+; Eval the expression with current error_reporting().  Set to true if you want
+; error_reporting(0) around the eval().
+; http://php.net/assert.quiet-eval
+;assert.quiet_eval = 0
+
+[COM]
+; path to a file containing GUIDs, IIDs or filenames of files with TypeLibs
+; http://php.net/com.typelib-file
+;com.typelib_file =
+
+; allow Distributed-COM calls
+; http://php.net/com.allow-dcom
+;com.allow_dcom = true
+
+; autoregister constants of a components typlib on com_load()
+; http://php.net/com.autoregister-typelib
+;com.autoregister_typelib = true
+
+; register constants casesensitive
+; http://php.net/com.autoregister-casesensitive
+;com.autoregister_casesensitive = false
+
+; show warnings on duplicate constant registrations
+; http://php.net/com.autoregister-verbose
+;com.autoregister_verbose = true
+
+; The default character set code-page to use when passing strings to and from COM objects.
+; Default: system ANSI code page
+;com.code_page=
+
+[mbstring]
+; language for internal character representation.
+; This affects mb_send_mail() and mbstrig.detect_order.
+; http://php.net/mbstring.language
+;mbstring.language = Japanese
+
+; Use of this INI entry is deprecated, use global internal_encoding instead.
+; internal/script encoding.
+; Some encoding cannot work as internal encoding. (e.g. SJIS, BIG5, ISO-2022-*)
+; If empty, default_charset or internal_encoding or iconv.internal_encoding is used.
+; The precedence is: default_charset < internal_encoding < iconv.internal_encoding
+;mbstring.internal_encoding =
+
+; Use of this INI entry is deprecated, use global input_encoding instead.
+; http input encoding.
+; mbstring.encoding_traslation = On is needed to use this setting.
+; If empty, default_charset or input_encoding or mbstring.input is used.
+; The precedence is: default_charset < intput_encoding < mbsting.http_input
+; http://php.net/mbstring.http-input
+;mbstring.http_input =
+
+; Use of this INI entry is deprecated, use global output_encoding instead.
+; http output encoding.
+; mb_output_handler must be registered as output buffer to function.
+; If empty, default_charset or output_encoding or mbstring.http_output is used.
+; The precedence is: default_charset < output_encoding < mbstring.http_output
+; To use an output encoding conversion, mbstring's output handler must be set
+; otherwise output encoding conversion cannot be performed.
+; http://php.net/mbstring.http-output
+;mbstring.http_output =
+
+; enable automatic encoding translation according to
+; mbstring.internal_encoding setting. Input chars are
+; converted to internal encoding by setting this to On.
+; Note: Do _not_ use automatic encoding translation for
+;       portable libs/applications.
+; http://php.net/mbstring.encoding-translation
+;mbstring.encoding_translation = Off
+
+; automatic encoding detection order.
+; "auto" detect order is changed according to mbstring.language
+; http://php.net/mbstring.detect-order
+;mbstring.detect_order = auto
+
+; substitute_character used when character cannot be converted
+; one from another
+; http://php.net/mbstring.substitute-character
+;mbstring.substitute_character = none
+
+; overload(replace) single byte functions by mbstring functions.
+; mail(), ereg(), etc are overloaded by mb_send_mail(), mb_ereg(),
+; etc. Possible values are 0,1,2,4 or combination of them.
+; For example, 7 for overload everything.
+; 0: No overload
+; 1: Overload mail() function
+; 2: Overload str*() functions
+; 4: Overload ereg*() functions
+; http://php.net/mbstring.func-overload
+;mbstring.func_overload = 0
+
+; enable strict encoding detection.
+; Default: Off
+;mbstring.strict_detection = On
+
+; This directive specifies the regex pattern of content types for which mb_output_handler()
+; is activated.
+; Default: mbstring.http_output_conv_mimetype=^(text/|application/xhtml\+xml)
+;mbstring.http_output_conv_mimetype=
+
+[gd]
+; Tell the jpeg decode to ignore warnings and try to create
+; a gd image. The warning will then be displayed as notices
+; disabled by default
+; http://php.net/gd.jpeg-ignore-warning
+;gd.jpeg_ignore_warning = 0
+
+[exif]
+; Exif UNICODE user comments are handled as UCS-2BE/UCS-2LE and JIS as JIS.
+; With mbstring support this will automatically be converted into the encoding
+; given by corresponding encode setting. When empty mbstring.internal_encoding
+; is used. For the decode settings you can distinguish between motorola and
+; intel byte order. A decode setting cannot be empty.
+; http://php.net/exif.encode-unicode
+;exif.encode_unicode = ISO-8859-15
+
+; http://php.net/exif.decode-unicode-motorola
+;exif.decode_unicode_motorola = UCS-2BE
+
+; http://php.net/exif.decode-unicode-intel
+;exif.decode_unicode_intel    = UCS-2LE
+
+; http://php.net/exif.encode-jis
+;exif.encode_jis =
+
+; http://php.net/exif.decode-jis-motorola
+;exif.decode_jis_motorola = JIS
+
+; http://php.net/exif.decode-jis-intel
+;exif.decode_jis_intel    = JIS
+
+[Tidy]
+; The path to a default tidy configuration file to use when using tidy
+; http://php.net/tidy.default-config
+;tidy.default_config = /usr/local/lib/php/default.tcfg
+
+; Should tidy clean and repair output automatically?
+; WARNING: Do not use this option if you are generating non-html content
+; such as dynamic images
+; http://php.net/tidy.clean-output
+tidy.clean_output = Off
+
+[soap]
+; Enables or disables WSDL caching feature.
+; http://php.net/soap.wsdl-cache-enabled
+soap.wsdl_cache_enabled=1
+
+; Sets the directory name where SOAP extension will put cache files.
+; http://php.net/soap.wsdl-cache-dir
+soap.wsdl_cache_dir="/tmp"
+
+; (time to live) Sets the number of second while cached file will be used
+; instead of original one.
+; http://php.net/soap.wsdl-cache-ttl
+soap.wsdl_cache_ttl=86400
+
+; Sets the size of the cache limit. (Max. number of WSDL files to cache)
+soap.wsdl_cache_limit = 5
+
+[sysvshm]
+; A default size of the shared memory segment
+;sysvshm.init_mem = 10000
+
+[ldap]
+; Sets the maximum number of open links or -1 for unlimited.
+ldap.max_links = -1
+
+[mcrypt]
+; For more information about mcrypt settings see http://php.net/mcrypt-module-open
+
+; Directory where to load mcrypt algorithms
+; Default: Compiled in into libmcrypt (usually /usr/local/lib/libmcrypt)
+;mcrypt.algorithms_dir=
+
+; Directory where to load mcrypt modes
+; Default: Compiled in into libmcrypt (usually /usr/local/lib/libmcrypt)
+;mcrypt.modes_dir=
+
+[dba]
+;dba.default_handler=
+
+[opcache]
+; Determines if Zend OPCache is enabled
+;opcache.enable=0
+
+; Determines if Zend OPCache is enabled for the CLI version of PHP
+;opcache.enable_cli=0
+
+; The OPcache shared memory storage size.
+;opcache.memory_consumption=64
+
+; The amount of memory for interned strings in Mbytes.
+;opcache.interned_strings_buffer=4
+
+; The maximum number of keys (scripts) in the OPcache hash table.
+; Only numbers between 200 and 100000 are allowed.
+;opcache.max_accelerated_files=2000
+
+; The maximum percentage of "wasted" memory until a restart is scheduled.
+;opcache.max_wasted_percentage=5
+
+; When this directive is enabled, the OPcache appends the current working
+; directory to the script key, thus eliminating possible collisions between
+; files with the same name (basename). Disabling the directive improves
+; performance, but may break existing applications.
+;opcache.use_cwd=1
+
+; When disabled, you must reset the OPcache manually or restart the
+; webserver for changes to the filesystem to take effect.
+;opcache.validate_timestamps=1
+
+; How often (in seconds) to check file timestamps for changes to the shared
+; memory storage allocation. ("1" means validate once per second, but only
+; once per request. "0" means always validate)
+;opcache.revalidate_freq=2
+
+; Enables or disables file search in include_path optimization
+;opcache.revalidate_path=0
+
+; If disabled, all PHPDoc comments are dropped from the code to reduce the
+; size of the optimized code.
+;opcache.save_comments=1
+
+; If disabled, PHPDoc comments are not loaded from SHM, so "Doc Comments"
+; may be always stored (save_comments=1), but not loaded by applications
+; that don't need them anyway.
+;opcache.load_comments=1
+
+; If enabled, a fast shutdown sequence is used for the accelerated code
+;opcache.fast_shutdown=0
+
+; Allow file existence override (file_exists, etc.) performance feature.
+;opcache.enable_file_override=0
+
+; A bitmask, where each bit enables or disables the appropriate OPcache
+; passes
+;opcache.optimization_level=0xffffffff
+
+;opcache.inherited_hack=1
+;opcache.dups_fix=0
+
+; The location of the OPcache blacklist file (wildcards allowed).
+; Each OPcache blacklist file is a text file that holds the names of files
+; that should not be accelerated. The file format is to add each filename
+; to a new line. The filename may be a full path or just a file prefix
+; (i.e., /var/www/x  blacklists all the files and directories in /var/www
+; that start with 'x'). Line starting with a ; are ignored (comments).
+;opcache.blacklist_filename=
+
+; Allows exclusion of large files from being cached. By default all files
+; are cached.
+;opcache.max_file_size=0
+
+; Check the cache checksum each N requests.
+; The default value of "0" means that the checks are disabled.
+;opcache.consistency_checks=0
+
+; How long to wait (in seconds) for a scheduled restart to begin if the cache
+; is not being accessed.
+;opcache.force_restart_timeout=180
+
+; OPcache error_log file name. Empty string assumes "stderr".
+;opcache.error_log=
+
+; All OPcache errors go to the Web server log.
+; By default, only fatal errors (level 0) or errors (level 1) are logged.
+; You can also enable warnings (level 2), info messages (level 3) or
+; debug messages (level 4).
+;opcache.log_verbosity_level=1
+
+; Preferred Shared Memory back-end. Leave empty and let the system decide.
+;opcache.preferred_memory_model=
+
+; Protect the shared memory from unexpected writing during script execution.
+; Useful for internal debugging only.
+;opcache.protect_memory=0
+
+; Validate cached file permissions.
+; opcache.validate_permission=0
+
+; Prevent name collisions in chroot'ed environment.
+; opcache.validate_root=0
+
+[curl]
+; A default value for the CURLOPT_CAINFO option. This is required to be an
+; absolute path.
+;curl.cainfo =
+
+[openssl]
+; The location of a Certificate Authority (CA) file on the local filesystem
+; to use when verifying the identity of SSL/TLS peers. Most users should
+; not specify a value for this directive as PHP will attempt to use the
+; OS-managed cert stores in its absence. If specified, this value may still
+; be overridden on a per-stream basis via the "cafile" SSL stream context
+; option.
+;openssl.cafile=
+
+; If openssl.cafile is not specified or if the CA file is not found, the
+; directory pointed to by openssl.capath is searched for a suitable
+; certificate. This value must be a correctly hashed certificate directory.
+; Most users should not specify a value for this directive as PHP will
+; attempt to use the OS-managed cert stores in its absence. If specified,
+; this value may still be overridden on a per-stream basis via the "capath"
+; SSL stream context option.
+;openssl.capath=
+
+; Local Variables:
+; tab-width: 4
+; End:

--- a/ansible/roles/php-56-zend/templates/php.ini
+++ b/ansible/roles/php-56-zend/templates/php.ini
@@ -293,17 +293,20 @@ serialize_precision = 17
 
 ; open_basedir, if set, limits all file operations to the defined directory
 ; and below.  This directive makes most sense if used in a per-directory
-; or per-virtualhost web server configuration file.
+; or per-virtualhost web server configuration file. This directive is
+; *NOT* affected by whether Safe Mode is turned On or Off.
 ; http://php.net/open-basedir
 ;open_basedir =
 
 ; This directive allows you to disable certain functions for security reasons.
-; It receives a comma-delimited list of function names.
+; It receives a comma-delimited list of function names. This directive is
+; *NOT* affected by whether Safe Mode is turned On or Off.
 ; http://php.net/disable-functions
 disable_functions =
 
 ; This directive allows you to disable certain classes for security reasons.
-; It receives a comma-delimited list of class names.
+; It receives a comma-delimited list of class names. This directive is
+; *NOT* affected by whether Safe Mode is turned On or Off.
 ; http://php.net/disable-classes
 disable_classes =
 
@@ -570,7 +573,7 @@ html_errors = On
 ; http://php.net/error-log
 ; Example:
 ;error_log = php_errors.log
-; Log errors to syslog (Event Log on Windows).
+; Log errors to syslog.
 ;error_log = syslog
 
 ;windows.show_crt_warning
@@ -608,13 +611,13 @@ html_errors = On
 ; http://php.net/variables-order
 variables_order = "GPCS"
 
-; This directive determines which super global data (G,P & C) should be
-; registered into the super global array REQUEST. If so, it also determines
-; the order in which that data is registered. The values for this directive
-; are specified in the same manner as the variables_order directive,
-; EXCEPT one. Leaving this value empty will cause PHP to use the value set
-; in the variables_order directive. It does not mean it will leave the super
-; globals array REQUEST empty.
+; This directive determines which super global data (G,P,C,E & S) should
+; be registered into the super global array REQUEST. If so, it also determines
+; the order in which that data is registered. The values for this directive are
+; specified in the same manner as the variables_order directive, EXCEPT one.
+; Leaving this value empty will cause PHP to use the value set in the
+; variables_order directive. It does not mean it will leave the super globals
+; array REQUEST empty.
 ; Default Value: None
 ; Development Value: "GP"
 ; Production Value: "GP"
@@ -667,14 +670,15 @@ auto_prepend_file =
 ; http://php.net/auto-append-file
 auto_append_file =
 
-; By default, PHP will output a media type using the Content-Type header. To
-; disable this, simply set it to be empty.
+; By default, PHP will output a character encoding using
+; the Content-type: header.  To disable sending of the charset, simply
+; set it to be empty.
 ;
-; PHP's built-in default media type is set to text/html.
+; PHP's built-in default is text/html
 ; http://php.net/default-mimetype
 default_mimetype = "text/html"
 
-; PHP's default character set is set to UTF-8.
+; PHP's default character set is set to empty.
 ; http://php.net/default-charset
 default_charset = "UTF-8"
 
@@ -684,12 +688,11 @@ default_charset = "UTF-8"
 ;internal_encoding =
 
 ; PHP input character encoding is set to empty.
-; If empty, default_charset is used.
 ; http://php.net/input-encoding
 ;input_encoding =
 
 ; PHP output character encoding is set to empty.
-; If empty, default_charset is used.
+; mbstring or iconv output handler is used.
 ; See also output_buffer.
 ; http://php.net/output-encoding
 ;output_encoding =
@@ -729,9 +732,9 @@ user_dir =
 
 ; Directory in which the loadable extensions (modules) reside.
 ; http://php.net/extension-dir
-extension_dir = "/usr/local/zend/php/5.6/lib/ext"
+; extension_dir = "./"
 ; On windows:
-;extension_dir = "/usr/local/zend/php/5.6/lib/ext"
+; extension_dir = "ext"
 
 ; Directory where the temporary files should be placed.
 ; Defaults to the system default (see sys_get_temp_dir)
@@ -770,11 +773,6 @@ enable_dl = Off
 ; http://php.net/cgi.fix-pathinfo
 ;cgi.fix_pathinfo=1
 
-; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
-; of the web tree and people will not be able to circumvent .htaccess security.
-; http://php.net/cgi.dicard-path
-;cgi.discard_path=1
-
 ; FastCGI under IIS (on WINNT based OS) supports the ability to impersonate
 ; security tokens of the calling client.  This allows IIS to define the
 ; security context that the request runs under.  mod_fastcgi under Apache
@@ -794,13 +792,6 @@ enable_dl = Off
 ; Default is zero.
 ; http://php.net/cgi.rfc2616-headers
 ;cgi.rfc2616_headers = 0
-
-; cgi.check_shebang_line controls whether CGI PHP checks for line starting with #!
-; (shebang) at the top of the running script. This line might be needed if the
-; script support running both as stand-alone script and via PHP CGI<. PHP in CGI
-; mode skips this line and ignores its content if this directive is turned on.
-; http://php.net/cgi.check-shebang-line
-;cgi.check_shebang_line=1
 
 ;;;;;;;;;;;;;;;;
 ; File Uploads ;
@@ -878,49 +869,11 @@ default_socket_timeout = 60
 ;
 ; If you only provide the name of the extension, PHP will look for it in its
 ; default extension directory.
-;
-; Windows Extensions
-; Note that ODBC support is built in, so no dll is needed for it.
-; Note that many DLL files are located in the extensions/ (PHP 4) ext/ (PHP 5)
-; extension folders as well as the separate PECL DLL download (PHP 5).
-; Be sure to appropriately set the extension_dir directive.
-;
-;extension=php_bz2.dll
-;extension=php_curl.dll
-;extension=php_fileinfo.dll
-;extension=php_gd2.dll
-;extension=php_gettext.dll
-;extension=php_gmp.dll
-;extension=php_intl.dll
-;extension=php_imap.dll
-;extension=php_interbase.dll
-;extension=php_ldap.dll
-;extension=php_mbstring.dll
-;extension=php_exif.dll      ; Must be after mbstring as it depends on it
-;extension=php_mysql.dll
-;extension=php_mysqli.dll
-;extension=php_oci8_12c.dll  ; Use with Oracle Database 12c Instant Client
-;extension=php_openssl.dll
-;extension=php_pdo_firebird.dll
-;extension=php_pdo_mysql.dll
-;extension=php_pdo_oci.dll
-;extension=php_pdo_odbc.dll
-;extension=php_pdo_pgsql.dll
-;extension=php_pdo_sqlite.dll
-;extension=php_pgsql.dll
-;extension=php_shmop.dll
 
-; The MIBS data available in the PHP distribution must be installed. 
-; See http://www.php.net/manual/en/snmp.installation.php 
-;extension=php_snmp.dll
-
-;extension=php_soap.dll
-;extension=php_sockets.dll
-;extension=php_sqlite3.dll
-;extension=php_sybase_ct.dll
-;extension=php_tidy.dll
-;extension=php_xmlrpc.dll
-;extension=php_xsl.dll
+;;;;
+; Note: packaged extension modules are now loaded via the .ini files
+; found in the directory /etc/php.d; these are loaded by default.
+;;;;
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;
@@ -978,21 +931,13 @@ date.timezone = Europe/London
 ; happens within intl functions. The value is the level of the error produced.
 ; Default is 0, which does not produce any errors.
 ;intl.error_level = E_WARNING
-;intl.use_exceptions = 0
+
+[sqlite]
+; http://php.net/sqlite.assoc-case
+;sqlite.assoc_case = 0
 
 [sqlite3]
-; Directory pointing to SQLite3 extensions
-; http://php.net/sqlite3.extension-dir
 ;sqlite3.extension_dir =
-
-; SQLite defensive mode flag (only available from SQLite 3.26+)
-; When the defensive flag is enabled, language features that allow ordinary
-; SQL to deliberately corrupt the database file are disabled. This forbids
-; writing directly to the schema, shadow tables (eg. FTS data tables), or
-; the sqlite_dbpage virtual table.
-; https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
-; (for older SQLite versions, this flag has no use)
-sqlite3.defensive = 1
 
 [Pcre]
 ;PCRE library backtracking limit.
@@ -1033,23 +978,13 @@ pdo_mysql.default_socket=
 ;phar.cache_list =
 
 [mail function]
-; For Win32 only.
-; http://php.net/smtp
-;SMTP = localhost
-; http://php.net/smtp-port
-;smtp_port = 25
-
-; For Win32 only.
-; http://php.net/sendmail-from
-;sendmail_from = me@example.com
-
 ; For Unix only.  You may supply arguments as well (default: "sendmail -t -i").
 ; http://php.net/sendmail-path
 sendmail_path = /usr/sbin/sendmail -t -i
 
 ; Force the addition of the specified parameters to be passed as extra parameters
 ; to the sendmail binary. These parameters will always replace the value of
-; the 5th parameter to mail().
+; the 5th parameter to mail(), even in safe mode.
 ;mail.force_extra_parameters =
 
 ; Add X-PHP-Originating-Script: that will include uid of the script followed by the filename
@@ -1058,7 +993,7 @@ mail.add_x_header = On
 ; The path to a log file that will log all mail() calls. Log entries include
 ; the full path of the script, line number, To address and headers.
 ;mail.log =
-; Log mail to syslog (Event Log on Windows).
+; Log mail to syslog;
 ;mail.log = syslog
 
 [SQL]
@@ -1261,19 +1196,6 @@ mysqlnd.collect_statistics = On
 ; http://php.net/mysqlnd.collect_memory_statistics
 mysqlnd.collect_memory_statistics = Off
 
-; Records communication from all extensions using mysqlnd to the specified log
-; file.
-; http://php.net/mysqlnd.debug
-;mysqlnd.debug =
-
-; Defines which queries will be logged.
-; http://php.net/mysqlnd.log_mask
-;mysqlnd.log_mask = 0
-
-; Default size of the mysqlnd memory pool, which is used by result sets.
-; http://php.net/mysqlnd.mempool_default_size
-;mysqlnd.mempool_default_size = 16000
-
 ; Size of a pre-allocated buffer used when sending commands to MySQL in bytes.
 ; http://php.net/mysqlnd.net_cmd_buffer_size
 ;mysqlnd.net_cmd_buffer_size = 2048
@@ -1282,15 +1204,6 @@ mysqlnd.collect_memory_statistics = Off
 ; bytes.
 ; http://php.net/mysqlnd.net_read_buffer_size
 ;mysqlnd.net_read_buffer_size = 32768
-
-; Timeout for network requests in seconds.
-; http://php.net/mysqlnd.net_read_timeout
-;mysqlnd.net_read_timeout = 31536000
-
-; SHA-256 Authentication Plugin related. File with the MySQL server public RSA
-; key.
-; http://php.net/mysqlnd.sha256_server_public_key
-;mysqlnd.sha256_server_public_key =
 
 [OCI8]
 
@@ -1453,6 +1366,10 @@ session.save_handler = files
 ; where MODE is the octal representation of the mode. Note that this
 ; does not overwrite the process's umask.
 ; http://php.net/session.save-path
+
+; RPM note : session directory must be owned by process owner
+; for mod_php, see /etc/httpd/conf.d/php.conf
+; for php-fpm, see /etc/php-fpm.d/*conf
 ;session.save_path = "/tmp"
 
 ; Whether to use strict session mode.
@@ -1736,31 +1653,6 @@ mssql.secure_connection = Off
 ; http://php.net/assert.quiet-eval
 ;assert.quiet_eval = 0
 
-[COM]
-; path to a file containing GUIDs, IIDs or filenames of files with TypeLibs
-; http://php.net/com.typelib-file
-;com.typelib_file =
-
-; allow Distributed-COM calls
-; http://php.net/com.allow-dcom
-;com.allow_dcom = true
-
-; autoregister constants of a components typlib on com_load()
-; http://php.net/com.autoregister-typelib
-;com.autoregister_typelib = true
-
-; register constants casesensitive
-; http://php.net/com.autoregister-casesensitive
-;com.autoregister_casesensitive = false
-
-; show warnings on duplicate constant registrations
-; http://php.net/com.autoregister-verbose
-;com.autoregister_verbose = true
-
-; The default character set code-page to use when passing strings to and from COM objects.
-; Default: system ANSI code page
-;com.code_page=
-
 [mbstring]
 ; language for internal character representation.
 ; This affects mb_send_mail() and mbstrig.detect_order.
@@ -1879,6 +1771,10 @@ soap.wsdl_cache_enabled=1
 
 ; Sets the directory name where SOAP extension will put cache files.
 ; http://php.net/soap.wsdl-cache-dir
+
+; RPM note : cache directory must be owned by process owner
+; for mod_php, see /etc/httpd/conf.d/php.conf
+; for php-fpm, see /etc/php-fpm.d/*conf
 soap.wsdl_cache_dir="/tmp"
 
 ; (time to live) Sets the number of second while cached file will be used
@@ -1910,108 +1806,6 @@ ldap.max_links = -1
 
 [dba]
 ;dba.default_handler=
-
-[opcache]
-; Determines if Zend OPCache is enabled
-;opcache.enable=0
-
-; Determines if Zend OPCache is enabled for the CLI version of PHP
-;opcache.enable_cli=0
-
-; The OPcache shared memory storage size.
-;opcache.memory_consumption=64
-
-; The amount of memory for interned strings in Mbytes.
-;opcache.interned_strings_buffer=4
-
-; The maximum number of keys (scripts) in the OPcache hash table.
-; Only numbers between 200 and 100000 are allowed.
-;opcache.max_accelerated_files=2000
-
-; The maximum percentage of "wasted" memory until a restart is scheduled.
-;opcache.max_wasted_percentage=5
-
-; When this directive is enabled, the OPcache appends the current working
-; directory to the script key, thus eliminating possible collisions between
-; files with the same name (basename). Disabling the directive improves
-; performance, but may break existing applications.
-;opcache.use_cwd=1
-
-; When disabled, you must reset the OPcache manually or restart the
-; webserver for changes to the filesystem to take effect.
-;opcache.validate_timestamps=1
-
-; How often (in seconds) to check file timestamps for changes to the shared
-; memory storage allocation. ("1" means validate once per second, but only
-; once per request. "0" means always validate)
-;opcache.revalidate_freq=2
-
-; Enables or disables file search in include_path optimization
-;opcache.revalidate_path=0
-
-; If disabled, all PHPDoc comments are dropped from the code to reduce the
-; size of the optimized code.
-;opcache.save_comments=1
-
-; If disabled, PHPDoc comments are not loaded from SHM, so "Doc Comments"
-; may be always stored (save_comments=1), but not loaded by applications
-; that don't need them anyway.
-;opcache.load_comments=1
-
-; If enabled, a fast shutdown sequence is used for the accelerated code
-;opcache.fast_shutdown=0
-
-; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
-
-; A bitmask, where each bit enables or disables the appropriate OPcache
-; passes
-;opcache.optimization_level=0xffffffff
-
-;opcache.inherited_hack=1
-;opcache.dups_fix=0
-
-; The location of the OPcache blacklist file (wildcards allowed).
-; Each OPcache blacklist file is a text file that holds the names of files
-; that should not be accelerated. The file format is to add each filename
-; to a new line. The filename may be a full path or just a file prefix
-; (i.e., /var/www/x  blacklists all the files and directories in /var/www
-; that start with 'x'). Line starting with a ; are ignored (comments).
-;opcache.blacklist_filename=
-
-; Allows exclusion of large files from being cached. By default all files
-; are cached.
-;opcache.max_file_size=0
-
-; Check the cache checksum each N requests.
-; The default value of "0" means that the checks are disabled.
-;opcache.consistency_checks=0
-
-; How long to wait (in seconds) for a scheduled restart to begin if the cache
-; is not being accessed.
-;opcache.force_restart_timeout=180
-
-; OPcache error_log file name. Empty string assumes "stderr".
-;opcache.error_log=
-
-; All OPcache errors go to the Web server log.
-; By default, only fatal errors (level 0) or errors (level 1) are logged.
-; You can also enable warnings (level 2), info messages (level 3) or
-; debug messages (level 4).
-;opcache.log_verbosity_level=1
-
-; Preferred Shared Memory back-end. Leave empty and let the system decide.
-;opcache.preferred_memory_model=
-
-; Protect the shared memory from unexpected writing during script execution.
-; Useful for internal debugging only.
-;opcache.protect_memory=0
-
-; Validate cached file permissions.
-; opcache.validate_permission=0
-
-; Prevent name collisions in chroot'ed environment.
-; opcache.validate_root=0
 
 [curl]
 ; A default value for the CURLOPT_CAINFO option. This is required to be an

--- a/ansible/roles/php-56-zend/templates/www.conf
+++ b/ansible/roles/php-56-zend/templates/www.conf
@@ -1,22 +1,432 @@
+; Start a new pool named 'www'.
+; the variable $pool can we used in any directive and will be replaced by the
+; pool name ('www' here)
 [www]
+
+; Per pool prefix
+; It only applies on the following directives:
+; - 'slowlog'
+; - 'listen' (unixsocket)
+; - 'chroot'
+; - 'chdir'
+; - 'php_values'
+; - 'php_admin_values'
+; When not set, the global prefix (or @php_fpm_prefix@) applies instead.
+; Note: This directive can also be relative to the global prefix.
+; Default Value: none
+;prefix = /path/to/pools/$pool
+
+; Unix user/group of processes
+; Note: The user is mandatory. If the group is not set, the default user's group
+;       will be used.
+; RPM: apache user chosen to provide access to the same directories as httpd
+user = vagrant
+; RPM: Keep a group allowed to write in log dir.
+group = vagrant
+
+; The address on which to accept FastCGI requests.
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific IPv4 address on
+;                            a specific port;
+;   '[ip:6:addr:ess]:port' - to listen on a TCP socket to a specific IPv6 address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all IPv4 addresses on a
+;                            specific port;
+;   '[::]:port'            - to listen on a TCP socket to all addresses
+;                            (IPv6 and IPv4-mapped) on a specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Note: This value is mandatory.
 listen = 127.0.0.1:9000
+
+; Set listen(2) backlog.
+; Default Value: 65535
+;listen.backlog = 65535
+
+; Set permissions for unix socket, if one is used. In Linux, read/write
+; permissions must be set in order to allow connections from a web server.
+; Default Values: user and group are set as the running user
+;                 mode is set to 0660
 listen.owner = vagrant
 listen.group = vagrant
 listen.mode = 0660
-user = vagrant
-group = vagrant
+
+; When POSIX Access Control Lists are supported you can set them using
+; these options, value is a comma separated list of user/group names.
+; When set, listen.owner and listen.group are ignored
+;listen.acl_users = apache
+;listen.acl_groups =
+
+; List of addresses (IPv4/IPv6) of FastCGI clients which are allowed to connect.
+; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original
+; PHP FCGI (5.2.2+). Makes sense only with a tcp listening socket. Each address
+; must be separated by a comma. If this value is left blank, connections will be
+; accepted from any ip address.
+; Default Value: any
+listen.allowed_clients = 127.0.0.1
+
+; Specify the nice(2) priority to apply to the pool processes (only if set)
+; The value can vary from -19 (highest priority) to 20 (lower priority)
+; Note: - It will only work if the FPM master process is launched as root
+;       - The pool processes will inherit the master process priority
+;         unless it specified otherwise
+; Default Value: no set
+; process.priority = -19
+
+; Set the process dumpable flag (PR_SET_DUMPABLE prctl) even if the process user
+; or group is differrent than the master process user. It allows to create process
+; core dump and ptrace the process for the pool user.
+; Default Value: no
+; process.dumpable = yes
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
 pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
 pm.max_children = 50
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
 pm.start_servers = 5
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
 pm.min_spare_servers = 5
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
 pm.max_spare_servers = 35
+ 
+; The number of seconds after which an idle process will be killed.
+; Note: Used only when pm is set to 'ondemand'
+; Default Value: 10s
+;pm.process_idle_timeout = 10s;
+
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
 pm.max_requests = 500
+
+; The URI to view the FPM status page. If this value is not set, no URI will be
+; recognized as a status page. It shows the following informations:
+;   pool                 - the name of the pool;
+;   process manager      - static, dynamic or ondemand;
+;   start time           - the date and time FPM has started;
+;   start since          - number of seconds since FPM has started;
+;   accepted conn        - the number of request accepted by the pool;
+;   listen queue         - the number of request in the queue of pending
+;                          connections (see backlog in listen(2));
+;   max listen queue     - the maximum number of requests in the queue
+;                          of pending connections since FPM has started;
+;   listen queue len     - the size of the socket queue of pending connections;
+;   idle processes       - the number of idle processes;
+;   active processes     - the number of active processes;
+;   total processes      - the number of idle + active processes;
+;   max active processes - the maximum number of active processes since FPM
+;                          has started;
+;   max children reached - number of times, the process limit has been reached,
+;                          when pm tries to start more children (works only for
+;                          pm 'dynamic' and 'ondemand');
+; Value are updated in real time.
+; Example output:
+;   pool:                 www
+;   process manager:      static
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          62636
+;   accepted conn:        190460
+;   listen queue:         0
+;   max listen queue:     1
+;   listen queue len:     42
+;   idle processes:       4
+;   active processes:     11
+;   total processes:      15
+;   max active processes: 12
+;   max children reached: 0
+;
+; By default the status page output is formatted as text/plain. Passing either
+; 'html', 'xml' or 'json' in the query string will return the corresponding
+; output syntax. Example:
+;   http://www.foo.bar/status
+;   http://www.foo.bar/status?json
+;   http://www.foo.bar/status?html
+;   http://www.foo.bar/status?xml
+;
+; By default the status page only outputs short status. Passing 'full' in the
+; query string will also return status for each pool process.
+; Example:
+;   http://www.foo.bar/status?full
+;   http://www.foo.bar/status?json&full
+;   http://www.foo.bar/status?html&full
+;   http://www.foo.bar/status?xml&full
+; The Full status returns for each process:
+;   pid                  - the PID of the process;
+;   state                - the state of the process (Idle, Running, ...);
+;   start time           - the date and time the process has started;
+;   start since          - the number of seconds since the process has started;
+;   requests             - the number of requests the process has served;
+;   request duration     - the duration in µs of the requests;
+;   request method       - the request method (GET, POST, ...);
+;   request URI          - the request URI with the query string;
+;   content length       - the content length of the request (only with POST);
+;   user                 - the user (PHP_AUTH_USER) (or '-' if not set);
+;   script               - the main script called (or '-' if not set);
+;   last request cpu     - the %cpu the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because CPU calculation is done when the request
+;                          processing has terminated;
+;   last request memory  - the max amount of memory the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because memory calculation is done when the request
+;                          processing has terminated;
+; If the process is in Idle state, then informations are related to the
+; last request the process has served. Otherwise informations are related to
+; the current request being served.
+; Example output:
+;   ************************
+;   pid:                  31330
+;   state:                Running
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          63087
+;   requests:             12808
+;   request duration:     1250261
+;   request method:       GET
+;   request URI:          /test_mem.php?N=10000
+;   content length:       0
+;   user:                 -
+;   script:               /home/fat/web/docs/php/test_mem.php
+;   last request cpu:     0.00
+;   last request memory:  0
+;
+; Note: There is a real-time FPM status monitoring sample web page available
+;       It's available in: @EXPANDED_DATADIR@/fpm/status.html
+;
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;pm.status_path = /status
+ 
+; The ping URI to call the monitoring page of FPM. If this value is not set, no
+; URI will be recognized as a ping page. This could be used to test from outside
+; that FPM is alive and responding, or to
+; - create a graph of FPM availability (rrd or such);
+; - remove a server from a group if it is not responding (load balancing);
+; - trigger alerts for the operating team (24/7).
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;ping.path = /ping
+
+; This directive may be used to customize the response of a ping request. The
+; response is formatted as text/plain with a 200 response code.
+; Default Value: pong
+;ping.response = pong
+ 
+; The access log file
+; Default: not set
+;access.log = log/$pool.access.log
+
+; The access log format.
+; The following syntax is allowed
+;  %%: the '%' character
+;  %C: %CPU used by the request
+;      it can accept the following format:
+;      - %{user}C for user CPU only
+;      - %{system}C for system CPU only
+;      - %{total}C  for user + system CPU (default)
+;  %d: time taken to serve the request
+;      it can accept the following format:
+;      - %{seconds}d (default)
+;      - %{miliseconds}d
+;      - %{mili}d
+;      - %{microseconds}d
+;      - %{micro}d
+;  %e: an environment variable (same as $_ENV or $_SERVER)
+;      it must be associated with embraces to specify the name of the env
+;      variable. Some exemples:
+;      - server specifics like: %{REQUEST_METHOD}e or %{SERVER_PROTOCOL}e
+;      - HTTP headers like: %{HTTP_HOST}e or %{HTTP_USER_AGENT}e
+;  %f: script filename
+;  %l: content-length of the request (for POST request only)
+;  %m: request method
+;  %M: peak of memory allocated by PHP
+;      it can accept the following format:
+;      - %{bytes}M (default)
+;      - %{kilobytes}M
+;      - %{kilo}M
+;      - %{megabytes}M
+;      - %{mega}M
+;  %n: pool name
+;  %o: output header
+;      it must be associated with embraces to specify the name of the header:
+;      - %{Content-Type}o
+;      - %{X-Powered-By}o
+;      - %{Transfert-Encoding}o
+;      - ....
+;  %p: PID of the child that serviced the request
+;  %P: PID of the parent of the child that serviced the request
+;  %q: the query string
+;  %Q: the '?' character if query string exists
+;  %r: the request URI (without the query string, see %q and %Q)
+;  %R: remote IP address
+;  %s: status (response code)
+;  %t: server time the request was received
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;  %T: time the log has been written (the request has finished)
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;  %u: remote user
+;
+; Default: "%R - %u %t \"%m %r\" %s"
+;access.format = "%R - %u %t \"%m %r%Q%q\" %s %f %{mili}d %{kilo}M %C%%"
+
+; The log file for slow requests
+; Default Value: not set
+; Note: slowlog is mandatory if request_slowlog_timeout is set
 slowlog = /var/log/php-fpm/slow.log
 
+; The timeout for serving a single request after which a PHP backtrace will be
+; dumped to the 'slowlog' file. A value of '0s' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_slowlog_timeout = 0
+
+; The timeout for serving a single request after which the worker process will
+; be killed. This option should be used when the 'max_execution_time' ini option
+; does not stop script execution for some reason. A value of '0' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_terminate_timeout = 0
+ 
+; Set open file descriptor rlimit.
+; Default Value: system defined value
+;rlimit_files = 1024
+ 
+; Set max core size rlimit.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+ 
+; Chroot to this directory at the start. This value must be defined as an
+; absolute path. When this value is not set, chroot is not used.
+; Note: you can prefix with '$prefix' to chroot to the pool prefix or one
+; of its subdirectories. If the pool prefix is not set, the global prefix
+; will be used instead.
+; Note: chrooting is a great security feature and should be used whenever
+;       possible. However, all PHP paths will be relative to the chroot
+;       (error_log, sessions.save_path, ...).
+; Default Value: not set
+;chroot = 
+ 
+; Chdir to this directory at the start.
+; Note: relative path can be used.
+; Default Value: current directory or / when chroot
+;chdir = /var/www
+ 
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Note: on highloaded environement, this can cause some delay in the page
+; process time (several ms).
+; Default Value: no
+;catch_workers_output = yes
+ 
+; Clear environment in FPM workers
+; Prevents arbitrary environment variables from reaching FPM worker processes
+; by clearing the environment in workers before env vars specified in this
+; pool configuration are added.
+; Setting to "no" will make all environment variables available to PHP code
+; via getenv(), $_ENV and $_SERVER.
+; Default Value: yes
+;clear_env = no
+
+; Limits the extensions of the main script FPM will allow to parse. This can
+; prevent configuration mistakes on the web server side. You should only limit
+; FPM to .php extensions to prevent malicious users to use other extensions to
+; exectute php code.
+; Note: set an empty value to allow all extensions.
+; Default Value: .php
+;security.limit_extensions = .php .php3 .php4 .php5
+
+; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
+; the current environment.
+; Default Value: clean env
+;env[HOSTNAME] = $HOSTNAME
+;env[PATH] = /usr/local/bin:/usr/bin:/bin
+;env[TMP] = /tmp
+;env[TMPDIR] = /tmp
+;env[TEMP] = /tmp
+
+; Additional php.ini defines, specific to this pool of workers. These settings
+; overwrite the values previously defined in the php.ini. The directives are the
+; same as the PHP SAPI:
+;   php_value/php_flag             - you can set classic ini defines which can
+;                                    be overwritten from PHP call 'ini_set'. 
+;   php_admin_value/php_admin_flag - these directives won't be overwritten by
+;                                     PHP call 'ini_set'
+; For php_*flag, valid values are on, off, 1, 0, true, false, yes or no.
+
+; Defining 'extension' will load the corresponding shared extension from
+; extension_dir. Defining 'disable_functions' or 'disable_classes' will not
+; overwrite previously defined php.ini values, but will append the new value
+; instead.
+
+; Note: path INI options can be relative and will be expanded with the prefix
+; (pool, global or @prefix@)
+
+; Default Value: nothing is defined by default except the values in php.ini and
+;                specified at startup with the -d argument
+;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
+;php_flag[display_errors] = off
 php_admin_value[error_log] = /var/log/php-fpm/error.log
 php_admin_value[access_log] = /var/log/php-fpm/access.log
 php_admin_flag[log_errors] = on
+;php_admin_value[memory_limit] = 128M
 
+; Set the following data paths to directories owned by the FPM process user.
+;
+; Do not change the ownership of existing system directories, if the process
+; user does not have write permission, create dedicated directories for this
+; purpose.
+;
+; See warning about choosing the location of these directories on your system
+; at http://php.net/session.save-path
 php_value[session.save_handler] = files
 php_value[session.save_path]    = /var/lib/php/session
 php_value[soap.wsdl_cache_dir]  = /var/lib/php/wsdlcache
+

--- a/ansible/roles/php-56-zend/templates/www.conf
+++ b/ansible/roles/php-56-zend/templates/www.conf
@@ -1,0 +1,22 @@
+[www]
+listen = 127.0.0.1:9000
+listen.owner = vagrant
+listen.group = vagrant
+listen.mode = 0660
+user = vagrant
+group = vagrant
+pm = dynamic
+pm.max_children = 50
+pm.start_servers = 5
+pm.min_spare_servers = 5
+pm.max_spare_servers = 35
+pm.max_requests = 500
+slowlog = /var/log/php-fpm/slow.log
+
+php_admin_value[error_log] = /var/log/php-fpm/error.log
+php_admin_value[access_log] = /var/log/php-fpm/access.log
+php_admin_flag[log_errors] = on
+
+php_value[session.save_handler] = files
+php_value[session.save_path]    = /var/lib/php/session
+php_value[soap.wsdl_cache_dir]  = /var/lib/php/wsdlcache

--- a/ansible/roles/php-56-zend/templates/xdebug-conf.ini
+++ b/ansible/roles/php-56-zend/templates/xdebug-conf.ini
@@ -1,0 +1,9 @@
+xdebug.remote_enable=1
+xdebug.remote_connect_back=1
+xdebug.remote_port=9000
+;This next line might not agree with Windows hosts, uncomment for OSX / PHPStorm
+;xdebug.remote_autostart=On
+xdebug.idekey=phpstorm
+xdebug.remote_log=/tmp/php-xdebug.log
+xdebug.extended_info=1
+xdebug.cli_color=1

--- a/ansible/roles/php-56/tasks/main.yml
+++ b/ansible/roles/php-56/tasks/main.yml
@@ -31,6 +31,11 @@
     src: php.ini
     dest: /opt/remi/php56/root/etc/php.ini
 
+- name: custom xdebug configuration .ini file
+  template:
+    src: xdebug-conf.ini
+    dest: /opt/remi/php56/root/etc/php.d/xdebug-conf.ini
+
 - name: www.cnf file
   template:
     src: www.conf

--- a/ansible/roles/php-56/tasks/main.yml
+++ b/ansible/roles/php-56/tasks/main.yml
@@ -18,6 +18,7 @@
     - php56-php-pecl-memcached
     - php56-php-mcrypt
     - php56-php-fpm
+    - php56-php-gd
 
 - name: set access log file
   file:

--- a/ansible/roles/php-56/templates/xdebug-conf.ini
+++ b/ansible/roles/php-56/templates/xdebug-conf.ini
@@ -1,0 +1,9 @@
+xdebug.remote_enable=1
+xdebug.remote_connect_back=1
+xdebug.remote_port=9000
+;This next line might not agree with Windows hosts, uncomment for OSX / PHPStorm
+;xdebug.remote_autostart=On
+xdebug.idekey=phpstorm
+xdebug.remote_log=/tmp/php-xdebug.log
+xdebug.extended_info=1
+xdebug.cli_color=1

--- a/ansible/roles/selinux/tasks/main.yml
+++ b/ansible/roles/selinux/tasks/main.yml
@@ -1,3 +1,3 @@
-# Disable SELinux; this is a dev env, and vagrant mounts over nfs, making relabelling difficult
+# Disable SELinux; this is a dev env, and vagrant mounts over nfs on Macs making relabelling difficult; on Windows hosts this also causes problems with shared folders
 - selinux:
     state: disabled

--- a/ansible/roles/shell/tasks/main.yml
+++ b/ansible/roles/shell/tasks/main.yml
@@ -39,10 +39,10 @@
 - name: enable Zend PHP 5.6 via supplied enabling script
   become: true
   become_user: vagrant
-  blockinfile:
+  lineinfile:
     path: ~/.bashrc
+    line: '{{ item }}'
     insertafter: 'EOF'
-    state: present
-    block: |
-      source /opt/zend/php56zend/enable
-    when: php_version == "Zend5.6"
+  with_items: "source /opt/zend/php56zend/enable"
+  when: php_version == "Zend5.6"
+  changed_when: false

--- a/ansible/roles/shell/tasks/main.yml
+++ b/ansible/roles/shell/tasks/main.yml
@@ -23,3 +23,15 @@
     insertafter: 'EOF'
   with_items: "{{ bash | default([]) }}"
   changed_when: false
+
+- name: insert custom mount bind into .bashrc for Windows-backed guest VMs
+  become: true
+  become_user: vagrant
+  blockinfile:
+    path: ~/.bashrc
+    insertafter: 'EOF'
+    state: present
+    block: |
+      alias vendormount='sudo mount --bind ~/vendor /bacpac/vendor'
+      alias vendorunmount='sudo umount ~/vendor'
+  when: windowshost == true

--- a/ansible/roles/shell/tasks/main.yml
+++ b/ansible/roles/shell/tasks/main.yml
@@ -35,3 +35,14 @@
       alias vendormount='sudo mount --bind ~/vendor /bacpac/vendor'
       alias vendorunmount='sudo umount ~/vendor'
   when: windowshost == true
+
+- name: enable Zend PHP 5.6 via supplied enabling script
+  become: true
+  become_user: vagrant
+  blockinfile:
+    path: ~/.bashrc
+    insertafter: 'EOF'
+    state: present
+    block: |
+      source /opt/zend/php56zend/enable
+    when: php_version == "Zend5.6"

--- a/ansible/roles/shell/templates/bashrc
+++ b/ansible/roles/shell/templates/bashrc
@@ -6,3 +6,6 @@ if [ -f /etc/bashrc ]; then
 fi
 
 # User specific aliases and functions
+if [ -f /opt/rh/python27/enable ]; then
+    . /opt/rh/python27/enable
+fi

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -16,6 +16,7 @@
   vars:
     packages:
     - http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
+  when: php_version != "Zend5.6"
 
 - name: setup third party repositories (mysql-community 5.7)
   yum:
@@ -37,6 +38,26 @@
 - name: Disable Mysql 5.7 repository when MySQL 5.5 requested
   command: "yum-config-manager --disable repository mysql57-community"
   when: mysql_version == "5.5"
+
+- name: Add ZendPHP 5.6 repository
+  yum_repository:
+    name: zend-server
+    description: Zend Enterprise PHP 5.6
+    baseurl: "https://{{zendphp_username}}:{{zendphp_password}}@repos.zend.com/zendphp/5.6/rpm_centos6/$basearch"
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: https://repos.zend.com/zend.key
+  when: php_version == "Zend5.6"
+
+- name: Add ZendPHP 5.6 noarch repository
+  yum_repository:
+    name: zend-server-noarch
+    description: Zend Enterprise PHP 5.6 noarch
+    baseurl: "https://{{zendphp_username}}:{{zendphp_password}}@repos.zend.com/zendphp/5.6/rpm_centos6/noarch"
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: https://repos.zend.com/zend.key
+  when: php_version == "Zend5.6"
 
 - name: update/install required packages 1
   yum:

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -35,6 +35,7 @@
     - mysql-connector-python
     - memcached
     - nginx
+    - ant
 
 - name: Lock packages to required versions
   shell: yum versionlock {{ item }}

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -49,6 +49,16 @@
     gpgkey: https://repos.zend.com/zend.key
   when: php_version == "Zend5.6"
 
+- name: Add ZendPHP 5.6 repository (noarch)
+  yum_repository:
+    name: zendphpnoarch
+    description: Zend Enterprise PHP 5.6 NoArch
+    baseurl: "https://{{zendphp_username}}:{{zendphp_password}}@repos.zend.com/zendphp/rpm_centos6/noarch"
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: https://repos.zend.com/zend.key
+  when: php_version == "Zend5.6"
+
 - name: update/install required packages 1
   yum:
     name: "{{ packages }}"

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -1,23 +1,13 @@
 ---
-#- name: install the epel rpm from a remote repo
-#  yum:
-#    name: epel-release
-#    state: latest
+- name: install the epel rpm from a remote repo
+  yum:
+    name: epel-release
+    state: latest
 
-#- name: add epel public key
-#  rpm_key:
-#    state: present
-#    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
-
-- name: Disable epel-release
-  command: "yum-config-manager --disable repository epel-release"
-
-- name: Add EPEL from alt source
-  yum_repository:
-    name: epel-alt
-    description: EPEL alt source
-    baseurl: https://vault.centos.org/6.10/os/$basearch
-    enabled: 1
+- name: add epel public key
+  rpm_key:
+    state: present
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
 
 - name: setup third party repository (remi)
   yum:
@@ -96,7 +86,7 @@
     name: "{{ packages }}"
     state: present
     enablerepo: mysql55-community
-    disablerepo: epel-alt
+    disablerepo: epel
     disable_gpg_check: yes
   vars:
     packages:

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -1,13 +1,23 @@
 ---
-- name: install the epel rpm from a remote repo
-  yum:
-    name: epel-release
-    state: latest
+#- name: install the epel rpm from a remote repo
+#  yum:
+#    name: epel-release
+#    state: latest
 
-- name: add epel public key
-  rpm_key:
-    state: present
-    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
+#- name: add epel public key
+#  rpm_key:
+#    state: present
+#    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
+
+- name: Disable epel-release
+  command: "yum-config-manager --disable repository epel-release"
+
+- name: Add EPEL from alt source
+  yum_repository:
+    name: epel-alt
+    description: EPEL alt source
+    baseurl: https://vault.centos.org/6.10/os/$basearch
+    enabled: 1
 
 - name: setup third party repository (remi)
   yum:
@@ -86,7 +96,7 @@
     name: "{{ packages }}"
     state: present
     enablerepo: mysql55-community
-    disablerepo: epel
+    disablerepo: epel-alt
     disable_gpg_check: yes
   vars:
     packages:

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -41,19 +41,9 @@
 
 - name: Add ZendPHP 5.6 repository
   yum_repository:
-    name: zend-server
+    name: zendphp
     description: Zend Enterprise PHP 5.6
-    baseurl: "https://{{zendphp_username}}:{{zendphp_password}}@repos.zend.com/zendphp/5.6/rpm_centos6/$basearch"
-    enabled: 1
-    gpgcheck: 1
-    gpgkey: https://repos.zend.com/zend.key
-  when: php_version == "Zend5.6"
-
-- name: Add ZendPHP 5.6 noarch repository
-  yum_repository:
-    name: zend-server-noarch
-    description: Zend Enterprise PHP 5.6 noarch
-    baseurl: "https://{{zendphp_username}}:{{zendphp_password}}@repos.zend.com/zendphp/5.6/rpm_centos6/noarch"
+    baseurl: "https://{{zendphp_username}}:{{zendphp_password}}@repos.zend.com/zendphp/rpm_centos6/$basearch"
     enabled: 1
     gpgcheck: 1
     gpgkey: https://repos.zend.com/zend.key

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -66,6 +66,7 @@
     state: present
     enablerepo: mysql55-community
     disablerepo: epel
+    disable_gpg_check: yes
   vars:
     packages:
       - mysql-community-server-5.5.41-2.el6.x86_64

--- a/ansible/roles/yum/tasks/main.yml
+++ b/ansible/roles/yum/tasks/main.yml
@@ -4,21 +4,41 @@
     name: epel-release
     state: latest
 
-- name: setup third party repositories (remi, mysql-community)
+- name: add epel public key
+  rpm_key:
+    state: present
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
+
+- name: setup third party repository (remi)
   yum:
     name: "{{ packages }}"
     state: present
   vars:
     packages:
     - http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
-    - http://repo.mysql.com/mysql57-community-release-el6.rpm
-  
-- name: add epel public key
-  rpm_key:
-    state: present
-    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
 
-- name: update/install required packages
+- name: setup third party repositories (mysql-community 5.7)
+  yum:
+    name: "{{ packages }}"
+    state: present
+  vars:
+    packages:
+    - "http://repo.mysql.com/mysql57-community-release-el6.rpm"
+  when: mysql_version=="5.7"
+
+- name: Add Mysql 5.5 repository
+  yum_repository:
+    name: mysql55-community
+    description: MySQl 5.5 Community Server
+    baseurl: http://repo.mysql.com/yum/mysql-5.5-community/el/6/$basearch
+    enabled: 1
+  when: mysql_version == "5.5"
+
+- name: Disable Mysql 5.7 repository when MySQL 5.5 requested
+  command: "yum-config-manager --disable repository mysql57-community"
+  when: mysql_version == "5.5"
+
+- name: update/install required packages 1
   yum:
     name: "{{ packages }}"
     state: latest
@@ -29,13 +49,41 @@
     - yum-plugin-versionlock
     - libselinux-python
     - git
-    - mysql-community-server
-    - mysql-community-client
-    - MySQL-python
-    - mysql-connector-python
-    - memcached
-    - nginx
-    - ant
+
+- name: update/install required packages MySQL 5.7
+  yum:
+    name: "{{ packages }}"
+    state: latest
+  vars:
+    packages:
+      - mysql-community-server
+      - mysql-community-client
+  when: mysql_version == "5.7"
+
+- name: update/install required packages MySQL 5.5
+  yum:
+    name: "{{ packages }}"
+    state: present
+    enablerepo: mysql55-community
+    disablerepo: epel
+  vars:
+    packages:
+      - mysql-community-server-5.5.41-2.el6.x86_64
+      - mysql-community-client-5.5.41-2.el6.x86_64
+  when: mysql_version == "5.5"
+
+- name: update/install required packages 2
+  yum:
+    name: "{{ packages }}"
+    state: latest
+  vars:
+    packages:
+      - MySQL-python
+      - mysql-connector-python
+      - memcached
+      - nginx
+      - ant
+
 
 - name: Lock packages to required versions
   shell: yum versionlock {{ item }}

--- a/prebuild-one.sh
+++ b/prebuild-one.sh
@@ -1,48 +1,52 @@
 #!/usr/bin/env bash
-cd /etc/yum.repos.d
-if [ ! -f "CentOS-Base.repo.bak" ]; then
-  printf "Backing up CentOS-Base.repo file"
-  sudo cp CentOS-Base.repo CentOS-Base.repo.bak
-fi
-
-printf "Amending CentOS-Base.repo"
-sudo sed -i 's|mirrorlist=|#mirrorlist=|g' CentOS-Base.repo
-sudo sed -i 's|#baseurl=|baseurl=|g' CentOS-Base.repo
-sudo sed -i 's|baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' CentOS-Base.repo
-
-cd -
-
-printf "Install scl"
-sudo yum install -y centos-release-scl
-
-cd /etc/yum.repos.d
-if [ ! -f "CentOS-SCLo-scl.repo.bak" ]; then
-  printf "Backing up CentOS-SCLo-scl.repo file"
-  sudo cp CentOS-SCLo-scl.repo CentOS-SCLo-scl.repo.bak
-fi
-
-printf "Amending CentOS-SCLo-scl.repo"
-sudo sed -i 's|mirrorlist=|#mirrorlist=|g' CentOS-SCLo-scl.repo
-sudo sed -i 's|# baseurl=|baseurl=|g' CentOS-SCLo-scl.repo
-sudo sed -i 's|baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' CentOS-SCLo-scl.repo
-
-if [ ! -f "CentOS-SCLo-scl-rh.repo.bak" ]; then
-  printf "Backing up CentOS-SCLo-scl-rh.repo file"
-  sudo cp CentOS-SCLo-scl-rh.repo CentOS-SCLo-scl-rh.repo.bak
-fi
-
-printf "Amending CentOS-SCLo-scl-rh.repo"
-sudo sed -i 's|mirrorlist=|#mirrorlist=|g' CentOS-SCLo-scl-rh.repo
-sudo sed -i 's|#baseurl=|baseurl=|g' CentOS-SCLo-scl-rh.repo
-sudo sed -i 's|baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' CentOS-SCLo-scl-rh.repo
+#cd /etc/yum.repos.d
+#if [ ! -f "CentOS-Base.repo.bak" ]; then
+#  printf "Backing up CentOS-Base.repo file"
+#  sudo cp CentOS-Base.repo CentOS-Base.repo.bak
+#fi
+#
+#printf "Amending CentOS-Base.repo"
+#sudo sed -i 's|mirrorlist=|#mirrorlist=|g' CentOS-Base.repo
+#sudo sed -i 's|#baseurl=|baseurl=|g' CentOS-Base.repo
+#sudo sed -i 's|baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' CentOS-Base.repo
+#
+#cd -
+#
+#printf "Install scl"
+#sudo yum install -y centos-release-scl
+#
+#cd /etc/yum.repos.d
+#if [ ! -f "CentOS-SCLo-scl.repo.bak" ]; then
+#  printf "Backing up CentOS-SCLo-scl.repo file"
+#  sudo cp CentOS-SCLo-scl.repo CentOS-SCLo-scl.repo.bak
+#fi
+#
+#printf "Amending CentOS-SCLo-scl.repo"
+#sudo sed -i 's|mirrorlist=|#mirrorlist=|g' CentOS-SCLo-scl.repo
+#sudo sed -i 's|# baseurl=|baseurl=|g' CentOS-SCLo-scl.repo
+#sudo sed -i 's|baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' CentOS-SCLo-scl.repo
+#
+#if [ ! -f "CentOS-SCLo-scl-rh.repo.bak" ]; then
+#  printf "Backing up CentOS-SCLo-scl-rh.repo file"
+#  sudo cp CentOS-SCLo-scl-rh.repo CentOS-SCLo-scl-rh.repo.bak
+#fi
+#
+#printf "Amending CentOS-SCLo-scl-rh.repo"
+#sudo sed -i 's|mirrorlist=|#mirrorlist=|g' CentOS-SCLo-scl-rh.repo
+#sudo sed -i 's|#baseurl=|baseurl=|g' CentOS-SCLo-scl-rh.repo
+#sudo sed -i 's|baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' CentOS-SCLo-scl-rh.repo
 
 printf "Install Python 2.7 via scl and set up for vagrant user"
 sudo yum install -y python27
 PYTHON27_CHECK=$(grep 'python27' ~/.bashrc | awk '{ print $1}')
-if [ -z "$PYTHON27_CHECK// " ]; then
-  sed -i "\$a\
-if [ -f /opt/rh/python27/enable ]; then\
-  . /opt/rh/python27/enable\
-fi" ~/.bashrc
-  source ~/.bashrc
+if [ -z "${PYTHON27_CHECK// }" ]; then
+    printf "Set up python2.7 for vagrant user";
+  echo '
+if [ -f /opt/rh/python27/enable ]; then
+  . /opt/rh/python27/enable
+fi' >> ~/.bashrc;
+    printf "bashrc modified for vagrant user";
+    source ~/.bashrc;
+  else
+    printf "python2.7 already set up for vagrant user"
 fi

--- a/prebuild-one.sh
+++ b/prebuild-one.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+cd /etc/yum.repos.d
+if [ ! -f "CentOS-Base.repo.bak" ]; then
+  printf "Backing up CentOS-Base.repo file"
+  sudo cp CentOS-Base.repo CentOS-Base.repo.bak
+fi
+
+printf "Amending CentOS-Base.repo"
+sudo sed -i 's|mirrorlist=|#mirrorlist=|g' CentOS-Base.repo
+sudo sed -i 's|#baseurl=|baseurl=|g' CentOS-Base.repo
+sudo sed -i 's|baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' CentOS-Base.repo
+
+cd -
+
+printf "Install scl"
+sudo yum install -y centos-release-scl
+
+cd /etc/yum.repos.d
+if [ ! -f "CentOS-SCLo-scl.repo.bak" ]; then
+  printf "Backing up CentOS-SCLo-scl.repo file"
+  sudo cp CentOS-SCLo-scl.repo CentOS-SCLo-scl.repo.bak
+fi
+
+printf "Amending CentOS-SCLo-scl.repo"
+sudo sed -i 's|mirrorlist=|#mirrorlist=|g' CentOS-SCLo-scl.repo
+sudo sed -i 's|# baseurl=|baseurl=|g' CentOS-SCLo-scl.repo
+sudo sed -i 's|baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' CentOS-SCLo-scl.repo
+
+if [ ! -f "CentOS-SCLo-scl-rh.repo.bak" ]; then
+  printf "Backing up CentOS-SCLo-scl-rh.repo file"
+  sudo cp CentOS-SCLo-scl-rh.repo CentOS-SCLo-scl-rh.repo.bak
+fi
+
+printf "Amending CentOS-SCLo-scl-rh.repo"
+sudo sed -i 's|mirrorlist=|#mirrorlist=|g' CentOS-SCLo-scl-rh.repo
+sudo sed -i 's|#baseurl=|baseurl=|g' CentOS-SCLo-scl-rh.repo
+sudo sed -i 's|baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' CentOS-SCLo-scl-rh.repo
+
+printf "Install Python 2.7 via scl and set up for vagrant user"
+sudo yum install -y python27
+PYTHON27_CHECK=$(grep 'python27' ~/.bashrc | awk '{ print $1}')
+if [ -z "$PYTHON27_CHECK// " ]; then
+  sed -i "\$a\
+if [ -f /opt/rh/python27/enable ]; then\
+  . /opt/rh/python27/enable\
+fi" ~/.bashrc
+  source ~/.bashrc
+fi

--- a/prebuild-rootsetup.sh
+++ b/prebuild-rootsetup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-REBUILD_CHECK=$(grep 'python27' ~/.bashrc | awk '{ print $1}')
-if [ -z "$REBUILD_CHECK// " ]; then
+PYTHON27_CHECK=$(grep 'python27' ~/.bashrc | awk '{ print $1}')
+if [ -z "${PYTHON27_CHECK// }" ]; then
   printf "Set up python2.7 for root user"
   sudo sed -i "\$a source /opt/rh/python27/enable" ~/.bashrc
 fi

--- a/prebuild-rootsetup.sh
+++ b/prebuild-rootsetup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+REBUILD_CHECK=$(grep 'python27' ~/.bashrc | awk '{ print $1}')
+if [ -z "$REBUILD_CHECK// " ]; then
+  printf "Set up python2.7 for root user"
+  sudo sed -i "\$a source /opt/rh/python27/enable" ~/.bashrc
+fi
+source ~/.bashrc

--- a/prebuild-two.sh
+++ b/prebuild-two.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # As root, install pip
-curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+curl -s https://bootstrap.pypa.io/2.7/get-pip.py -o get-pip.py
 python --version
 python get-pip.py

--- a/prebuild-two.sh
+++ b/prebuild-two.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# As root, install pip
+curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python --version
+python get-pip.py


### PR DESCRIPTION
This set of changes comprises build support on a Windows host for a combined bacpac & paywall machine, and incorporates the changes required to build bacpac and paywall using ZendPHP and MySQL5.5 or 5.7.

Although we are now not using Windows laptops for development, the changes maintained support for Mac hosts as we were a mixed Windows/Mac team during this branch's lifetime. In addition, during the duration of the branch, both bacpac & paywall were migrated from MySQL5.5. to 5.7; the missing MySQL5.5 support was added to the Ansible setup to match what was the live setup at the time.

This pull request was created to bring all the work back, as a record, into a Mayden-controlled GitHub repository rather than remaining reliant upon a fork on a Mayden-developer's own GitHub account.