### PR TITLE
Updating setup for VM suitable for bacpac & paywall development

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,37 +19,6 @@ vagrant plugin install vagrant-vbguest
 vagrant up
 ```
 
-For Windows:
-```
-cp ansible/group_vars/all.example ansible/group_vars/all
-vagrant plugin install vagrant-vbguest
-vagrant up (this will fail at the initial Ansible provision step)
-(copy generated vagrant user private key into VM and set up SSH config - see below for one-off intervention)
-vagrant reload --provision
-```
-Ansible cannot be installed on Windows, and so it will be installed into the VM by Vagrant and then run from within to
-provision the VM. However, the initial Ansible run fails as the VM needs to be able to provision itself via an SSH
-connection but cannot connect at this stage.
-The one-off manual steps to rectify this are as follows:
-1. Copy the generated `private_key` from `.vagrant/machines/default/virtualbox` into the VM for vagrant user as `~/.ssh/private_key`
-2. SSH into the VM
-3. Change directory to `~/.ssh`
-4. Create the SSH configuration file `~/.ssh/config` with the following content (using spaces rather than tabs):
-    ```
-    Host 192.168.33.35
-        IdentityFile ~/.ssh/private_key
-        User vagrant
-    ```
-5. Change the access permissions on the `config` and `private_key` files to 0600: `chmod 0600 config private_key`
-6. Required step: Test that you have set this up correctly by SSHing to the VM from within as the vagrant user `ssh 192.168.33.35` - you'll need
-to accept the question about connecting to an unknown host; don't forget to `exit` before continuing with provisioning
-the VM.
-
-For Windows hosts, two aliases are added into the `~/.bashrc` file
-- `vendormount` to mount bind '~/vendor' to `/bacpac/vendor`
-- `vendorunmount` to remove the above mount.
-These have been added to specifically work around shared folder issues for Windows hosts while working on **bacpac**.
-
 ## Shared directories
 Host-VM shared directories have been set up for:
 - `/vagrant` (the standard share of the host directory in which the Vagrantfile resides)
@@ -90,7 +59,7 @@ After changing any ansible settings just run `vagrant up --provision` to propaga
 
   Install VirtualBox, instructions can be found here: [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 
-- **Ansible (Mac only)**
+- **Ansible**
 
   Install Ansible, instructions can be found here: [Ansible](http://docs.ansible.com/ansible/intro_installation.html#installing-the-control-machine)
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 - Memcache 1.4.1
 
 ### Run
-
 Edit the `all` file to suit once copied.
 Note that, for a VM suitable for bacpac and paywall, the `fastcgi_read_timeout` value in `all.example` has been updated to 300s as per task #142741, but only needs to be this value for bacpac. For paywall it must be reset to 60s after the VM has been built by manually editing the generated nginx configuration file for the paywall host in the VM (generated in `/etc/nginx/conf.d/`), setting the value back to `60`, then reloading the nginx configuration (`nginx -t` to test the change, if ok then run `sudo service nginx reload`) .
 
 For Macs:
 ```
 cp ansible/group_vars/all.example ansible/group_vars/all
+vim ansible/group_var/all
 vagrant plugin install vagrant-vbguest
 vagrant up
 ```
@@ -22,7 +22,6 @@ vagrant up
 ## Shared directories
 Host-VM shared directories have been set up for:
 - `/vagrant` (the standard share of the host directory in which the Vagrantfile resides)
-- `/ansible` (this repository's `ansible` directory required for Ansible provisioning when on Windows hosts)
 - `/bacpac` (this expects to find the `bacpac` codebase in a directory name `bacpac` at the same level as this repository)
 - `/paywall` (this expects to find the `paywall` codebase in a directory name `paywall` at the same level as this repository)
 
@@ -34,7 +33,6 @@ Add a new entry to the `virtual_hosts` dictionary in the `ansible/group_vars/all
 Add the following line `192.168.33.35 {host_name}` (where the `{host_name}` is the one from the `all` file) to your hosts file `/etc/hosts`
 
 ### Change PHP Versions
-
 Edit `ansible/group_vars/all` with your favourite editor and change the `php_version` variable. The only allowed version
 numbers at this time are for PHP 5.5, 5.6, 7.2, 7.4 and Zend PHP 5.6.40 (use `5.5`, `5.6`, `7.2`, `7.4` or `Zend5.6`).
 The Zend PHP selection is only for use with bacpac and paywall and requires the use of credentials stored in 1Password.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,11 @@ Vagrant.configure("2") do |config|
 
     default.vm.network :private_network, ip: "192.168.33.35"
 
+    if OS.windows?
+      puts 'Building on Windows is no longer supported'
+      abort
+    end
+
     # Need to adjust specific yum.repos.d/*.repo files due to CentOS6 being EOL
     default.vbguest.installer_hooks[:before_install] = [
     "cd /etc/yum.repos.d; if [ ! -f \"CentOS-Base.repo.bak\" ]; then printf \"Backing up CentOS-Base.repo file\"; sudo cp /etc/yum.repos.d/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo.bak; fi",
@@ -72,43 +77,13 @@ Vagrant.configure("2") do |config|
       v.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
     end
 
-    if OS.windows?
-    # use shell provisioner to bootstrap - fix yum.repos.d/centos-base file (disable mirror, enable baseurl, change baseurl to vault.centos.org in all cases)
-    # then install scl, use scl to install python 2.7, install pip
-    #
-    # Bootstrap shell script
-     config.vm.provision :shell, path: "prebuild-one.sh", privileged: false, name: "prebuild - one"
-     config.vm.provision :shell, path: "prebuild-rootsetup.sh", privileged: true, name: "prebuild - root setup"
-     config.vm.provision :shell, path: "prebuild-two.sh", privileged: true, name: "prebuild - two"
-    # then use ansible_local provisioner
-      default.vm.provision "ansible_local" do |ansible|
-        ansible.compatibility_mode = "2.0"
-        ansible.install_mode = "pip"
-        # pip already installed in custom provisioning script prebuild-two.sh so have to override the default install script (shown below)
-        # with a dummy version "true" so that the Ansible provisioner does not override our changes
-        #ansible.pip_install_cmd = "curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py; sudo python get-pip.py"
-        ansible.pip_install_cmd = "true"
-        ansible.playbook = "/ansible/install.yml"
-        ansible.inventory_path = "/ansible/hosts"
-        # Uncomment the next line for increased output from Ansible provisioning, change to "-vvv" for debug level output
-        #ansible.verbose = true
-        ansible.provisioning_path = "/ansible"
-        ansible.extra_vars = {
-          windowshost: true
-        }
-
-      end
-    else
-      default.vm.provision "ansible" do |ansible|
-        ansible.compatibility_mode = "2.0"
-        ansible.playbook = "ansible/install.yml"
-        ansible.inventory_path = "ansible/hosts"
-        # Uncomment the next line for increased output from Ansible provisioning, change to "-vvv" for debug level output
-        #ansible.verbose = true
-        ansible.extra_vars = {
-          windowshost: false
-        }
-      end
+    default.vm.provision "ansible" do |ansible|
+      ansible.compatibility_mode = "2.0"
+      ansible.playbook = "ansible/install.yml"
+      ansible.inventory_path = "ansible/hosts"
+      # Uncomment the next line for increased output from Ansible provisioning, change to "-vvv" for debug level output
+      #ansible.verbose = true
     end
+
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,19 +54,16 @@ Vagrant.configure("2") do |config|
     # Shared folder
     if OS.windows?
       default.vm.synced_folder "www", "/vagrant", type: "virtualbox"
-      default.vm.synced_folder "ansible", "/ansible", type: "virtualbox"
       default.vm.synced_folder "../bacpac", "/bacpac", type: "virtualbox"
       default.vm.synced_folder "../paywall", "/paywall", type: "virtualbox"
     end
     if OS.linux?
       default.vm.synced_folder "www", "/vagrant", :nfs => true
-      default.vm.synced_folder "ansible", "/ansible", :nfs => true
       default.vm.synced_folder "../bacpac", "/bacpac", :nfs => true
       default.vm.synced_folder "../paywall", "/paywall", :nfs => true
     end
     if OS.mac?
       default.vm.synced_folder "www", "/vagrant", :nfs => true, mount_options: ['rw', 'vers=3', 'tcp', 'fsc' ,'actimeo=2']
-      default.vm.synced_folder "ansible", "/ansible", :nfs => true, mount_options: ['rw', 'vers=3', 'tcp', 'fsc', 'actimeo=2']
       default.vm.synced_folder "../bacpac", "/bacpac", :nfs => true, mount_options: ['rw', 'vers=3', 'tcp', 'fsc', 'actimeo=2']
       default.vm.synced_folder "../paywall", "/paywall", :nfs => true, mount_options: ['rw', 'vers=3', 'tcp', 'fsc', 'actimeo=2']
     end

--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -13,7 +13,7 @@ mysql_port: 3306
 mysql_root_db_user: dbuser
 
 # MySQL Root Pass
-mysql_root_db_pass: 'SomeSuperLongPassword1234!'
+mysql_root_db_pass: 'u.7mXTFfu3w.cYwwC_HZy6aF'
 
 # custom my.cnf settings
 #mysqld:

--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -36,7 +36,7 @@ node_version: v11
 fastcgi_read_timeout: 300
 
 # PHP Version
-php_version: "5.6"
+php_version: "Zend5.6"
 
 # ZendPHP PHP 5.6 repository credentials - for use with Zend PHP installation for bacpac only - see 1Password
 zendphp_username:

--- a/ansible/roles/check-variables/tasks/main.yml
+++ b/ansible/roles/check-variables/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-- fail:
+- name: Validate PHP version selected
+  fail:
     msg: "Invalid PHP Version"
   when:
     - php_version != "5.5"
@@ -8,7 +9,8 @@
     - php_version != "7.3"
     - php_version != "Zend5.6"
 
-- fail:
+- name: Validate MySQL version selected
+  fail:
     msg: "Invalid MySQL Version"
   when:
     - mysql_version != "5.5"

--- a/ansible/roles/check-variables/tasks/main.yml
+++ b/ansible/roles/check-variables/tasks/main.yml
@@ -15,3 +15,9 @@
   when:
     - mysql_version != "5.5"
     - mysql_version != "5.7"
+
+- name: Ensure credentials supplied if Zend PHP selected
+  fail:
+    msg: "Missing credentials for use with Zend PHP"
+  when:
+    - php_version == "Zend5.6" and (zendphp_username == "" or zendphp_password == "")

--- a/ansible/roles/composer/tasks/main.yml
+++ b/ansible/roles/composer/tasks/main.yml
@@ -13,9 +13,9 @@
 - name: foo
   debug: var=php_binarys
 
-- name: Install PHP Composer 2.1.12
+- name: Install PHP Composer 2.1.14
   get_url:
-    url: https://getcomposer.org/download/2.1.12/composer.phar
+    url: https://getcomposer.org/download/2.1.14/composer.phar
     dest: /usr/local/bin/composer
     mode: 0755
 

--- a/ansible/roles/composer/tasks/main.yml
+++ b/ansible/roles/composer/tasks/main.yml
@@ -7,12 +7,6 @@
     file_type: link
   register: php_binarys
 
-- name: foo1
-  debug: var=phppattern
-
-- name: foo
-  debug: var=php_binarys
-
 - name: Install PHP Composer 2.1.14
   get_url:
     url: https://getcomposer.org/download/2.1.14/composer.phar

--- a/ansible/roles/composer/tasks/main.yml
+++ b/ansible/roles/composer/tasks/main.yml
@@ -13,9 +13,9 @@
 - name: foo
   debug: var=php_binarys
 
-- name: Install PHP Composer 1.10.8
+- name: Install PHP Composer 2.1.12
   get_url:
-    url: https://getcomposer.org/download/1.10.8/composer.phar
+    url: https://getcomposer.org/download/2.1.12/composer.phar
     dest: /usr/local/bin/composer
     mode: 0755
 

--- a/ansible/roles/shell/tasks/main.yml
+++ b/ansible/roles/shell/tasks/main.yml
@@ -24,18 +24,6 @@
   with_items: "{{ bash | default([]) }}"
   changed_when: false
 
-- name: insert custom mount bind into .bashrc for Windows-backed guest VMs
-  become: true
-  become_user: vagrant
-  blockinfile:
-    path: ~/.bashrc
-    insertafter: 'EOF'
-    state: present
-    block: |
-      alias vendormount='sudo mount --bind ~/vendor /bacpac/vendor'
-      alias vendorunmount='sudo umount ~/vendor'
-  when: windowshost == true
-
 - name: enable Zend PHP 5.6 via supplied enabling script
   become: true
   become_user: vagrant

--- a/ansible/roles/shell/templates/bash_profile
+++ b/ansible/roles/shell/templates/bash_profile
@@ -12,7 +12,7 @@ fi
 
 # User specific environment and startup programs
 
-PATH=$PATH:$HOME/bin:~/.composer/vendor/bin
+PATH=$PATH:$HOME/bin:~/.config/composer/vendor/bin:~/.composer/vendor/bin
 
 
 export PATH


### PR DESCRIPTION
Incorporating further changes for building a VM suitable for bacpac & paywall development in line with the live application environments.

These changes update the README.md file, bring an updated version of Composer (2.1.14), remove support for building the VM on Windows hosts, update the default MySQL 5.7 password and specify ZendPHP by default for VM builds intended for bacpac and paywall.